### PR TITLE
Use names from assets when spawning them

### DIFF
--- a/editor/src/liquidator/asset/gltf/PrefabStep.cpp
+++ b/editor/src/liquidator/asset/gltf/PrefabStep.cpp
@@ -81,6 +81,9 @@ void loadPrefabs(GLTFImportData &importData) {
 
     prefab.data.transforms.push_back({localEntityId, transform});
 
+    prefab.data.names.push_back(
+        {localEntityId, node.name.empty() ? "Untitled" : node.name});
+
     if (hasValidMesh) {
       if (node.skin >= 0) {
         prefab.data.skinnedMeshes.push_back(

--- a/editor/tests/liquidator-tests/actions/SpawnEntityActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/SpawnEntityActions.test.cpp
@@ -308,6 +308,7 @@ using SpawnSpriteAtViewActionTest = ActionTestBase;
 
 TEST_P(SpawnSpriteAtViewActionTest, ExecutorSpawnsSpriteAtView) {
   liquid::AssetData<liquid::TextureAsset> data{};
+  data.relativePath = liquid::Path("test-path") / "my-texture.ktx2";
   data.data.deviceHandle = liquid::rhi::TextureHandle{25};
   auto textureAsset = assetRegistry.getTextures().addAsset(data);
 
@@ -334,7 +335,7 @@ TEST_P(SpawnSpriteAtViewActionTest, ExecutorSpawnsSpriteAtView) {
                 .localPosition,
             glm::vec3(0.0f, 0.0f, -10.0f));
   EXPECT_EQ(activeScene().entityDatabase.get<liquid::Name>(entity).name,
-            "New sprite");
+            "my-texture");
   EXPECT_TRUE(activeScene().entityDatabase.has<liquid::WorldTransform>(entity));
   EXPECT_TRUE(activeScene().entityDatabase.has<liquid::Sprite>(entity));
 

--- a/engine/src/liquid/asset/AssetCachePrefab.cpp
+++ b/engine/src/liquid/asset/AssetCachePrefab.cpp
@@ -156,6 +156,16 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
 
   {
+    auto numComponents = static_cast<uint32_t>(asset.data.names.size());
+    file.write(numComponents);
+
+    for (auto &name : asset.data.names) {
+      file.write(name.entity);
+      file.write(name.value);
+    }
+  }
+
+  {
     auto numComponents = static_cast<uint32_t>(asset.data.meshes.size());
     file.write(numComponents);
     for (auto &component : asset.data.meshes) {
@@ -377,6 +387,22 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   {
     uint32_t numComponents = 0;
     stream.read(numComponents);
+    prefab.data.names.resize(numComponents);
+    for (uint32_t i = 0; i < numComponents; ++i) {
+      uint32_t entity = 0;
+      stream.read(entity);
+
+      String name;
+      stream.read(name);
+
+      prefab.data.names.at(i).entity = entity;
+      prefab.data.names.at(i).value = name;
+    }
+  }
+
+  {
+    uint32_t numComponents = 0;
+    stream.read(numComponents);
 
     prefab.data.meshes.resize(numComponents);
 
@@ -506,7 +532,7 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   if (prefab.data.transforms.empty() && prefab.data.directionalLights.empty() &&
       prefab.data.pointLights.empty() && prefab.data.meshes.empty() &&
       prefab.data.skinnedMeshes.empty() && prefab.data.skeletons.empty() &&
-      prefab.data.animators.empty()) {
+      prefab.data.animators.empty() && prefab.data.names.empty()) {
     return Result<PrefabAssetHandle>::Error("Prefab is empty");
   }
 

--- a/engine/src/liquid/asset/PrefabAsset.h
+++ b/engine/src/liquid/asset/PrefabAsset.h
@@ -95,6 +95,11 @@ struct PrefabAsset {
    * List of directional lights
    */
   std::vector<PrefabComponent<DirectionalLight>> directionalLights;
+
+  /**
+   * @brief List of entity names
+   */
+  std::vector<PrefabComponent<String>> names;
 };
 
 } // namespace liquid

--- a/engine/tests/liquid-tests/asset/AssetCachePrefab.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCachePrefab.test.cpp
@@ -30,6 +30,7 @@ public:
     uint32_t numSkeletons = 3;
     uint32_t numDirectionalLights = 2;
     uint32_t numPointLights = 4;
+    uint32_t numNames = 3;
 
     for (uint32_t i = 0; i < numTransforms; ++i) {
       liquid::PrefabTransformData transform{};
@@ -39,6 +40,12 @@ public:
       transform.parent = idist(mt);
 
       asset.data.transforms.push_back({i, transform});
+    }
+
+    for (uint32_t i = 0; i < numNames; ++i) {
+      liquid::String name = "Test name " + std::to_string(i);
+
+      asset.data.names.push_back({i, name});
     }
 
     for (uint32_t i = 0; i < numDirectionalLights; ++i) {
@@ -291,6 +298,23 @@ TEST_F(AssetCacheTest, CreatesPrefabFile) {
   {
     uint32_t numComponents = 0;
     file.read(numComponents);
+    EXPECT_EQ(numComponents, 3);
+
+    for (uint32_t i = 0; i < numComponents; ++i) {
+      uint32_t entity = 999;
+      file.read(entity);
+      EXPECT_EQ(entity, i);
+
+      liquid::String name;
+      file.read(name);
+
+      EXPECT_EQ(asset.data.names.at(i).value, name);
+    }
+  }
+
+  {
+    uint32_t numComponents = 0;
+    file.read(numComponents);
     EXPECT_EQ(numComponents, 7);
     auto &map = cache.getRegistry().getMeshes();
     for (uint32_t i = 0; i < numComponents; ++i) {
@@ -474,6 +498,14 @@ TEST_F(AssetCacheTest, LoadsPrefabFile) {
     EXPECT_EQ(expected.value.rotation, actual.value.rotation);
     EXPECT_EQ(expected.value.scale, actual.value.scale);
     EXPECT_EQ(expected.value.parent, actual.value.parent);
+  }
+
+  EXPECT_EQ(asset.data.names.size(), prefab.data.names.size());
+  for (size_t i = 0; i < prefab.data.names.size(); ++i) {
+    auto &expected = asset.data.names.at(i);
+    auto &actual = prefab.data.names.at(i);
+    EXPECT_EQ(expected.entity, actual.entity);
+    EXPECT_EQ(expected.value, actual.value);
   }
 
   EXPECT_EQ(asset.data.meshes.size(), prefab.data.meshes.size());


### PR DESCRIPTION
- Add GLTF node names to prefab
- Add entity names when spawning prefabs
- Use prefab name for root node
- Use texture name wen spawning sprites