### PR TITLE
Create asset metadata

### DIFF
--- a/editor/src/liquidator/asset/AssetManager.cpp
+++ b/editor/src/liquidator/asset/AssetManager.cpp
@@ -344,8 +344,11 @@ Result<Path> AssetManager::loadOriginalTexture(const Path &originalAssetPath) {
 
     if (std::filesystem::copy_file(originalAssetPath, engineAssetPath,
                                    co::overwrite_existing)) {
+      auto metaRes =
+          mAssetCache.createMetaFile(AssetType::Texture, engineAssetPath);
       auto res = mAssetCache.loadAsset(engineAssetPath);
-      if (res.hasData()) {
+
+      if (res.hasData() && metaRes.hasData()) {
         return Result<Path>::Ok(engineAssetPath);
       }
 
@@ -365,8 +368,11 @@ Result<Path> AssetManager::loadOriginalAudio(const Path &originalAssetPath) {
 
   if (std::filesystem::copy_file(originalAssetPath, engineAssetPath,
                                  co::overwrite_existing)) {
+    auto metaRes =
+        mAssetCache.createMetaFile(AssetType::Audio, engineAssetPath);
     auto res = mAssetCache.loadAsset(engineAssetPath);
-    if (res.hasData()) {
+
+    if (res.hasData() && metaRes.hasData()) {
       return Result<Path>::Ok(engineAssetPath);
     }
 
@@ -381,8 +387,11 @@ Result<Path> AssetManager::loadOriginalScript(const Path &originalAssetPath) {
 
   if (std::filesystem::copy_file(originalAssetPath, engineAssetPath,
                                  co::overwrite_existing)) {
+    auto metaRes =
+        mAssetCache.createMetaFile(AssetType::LuaScript, engineAssetPath);
     auto res = mAssetCache.loadAsset(engineAssetPath);
-    if (res.hasData()) {
+
+    if (res.hasData() && metaRes.hasData()) {
       return Result<Path>::Ok(engineAssetPath);
     }
 
@@ -400,8 +409,10 @@ Result<Path> AssetManager::loadOriginalFont(const Path &originalAssetPath) {
 
   if (std::filesystem::copy_file(originalAssetPath, engineAssetPath,
                                  co::overwrite_existing)) {
+    auto metaRes = mAssetCache.createMetaFile(AssetType::Font, engineAssetPath);
     auto res = mAssetCache.loadAsset(engineAssetPath);
-    if (res.hasData()) {
+
+    if (res.hasData() && metaRes.hasData()) {
       return Result<Path>::Ok(engineAssetPath);
     }
     std::filesystem::remove(engineAssetPath);
@@ -415,10 +426,14 @@ Result<Path> AssetManager::loadOriginalAnimator(const Path &originalAssetPath) {
 
   if (std::filesystem::copy_file(originalAssetPath, engineAssetPath,
                                  co::overwrite_existing)) {
+    auto metaRes =
+        mAssetCache.createMetaFile(AssetType::Animator, engineAssetPath);
     auto res = mAssetCache.loadAsset(engineAssetPath);
-    if (res.hasData()) {
+
+    if (res.hasData() && metaRes.hasData()) {
       return Result<Path>::Ok(engineAssetPath, res.getWarnings());
     }
+
     std::filesystem::remove(engineAssetPath);
   }
 

--- a/editor/src/liquidator/asset/AssetManager.h
+++ b/editor/src/liquidator/asset/AssetManager.h
@@ -116,6 +116,13 @@ public:
   }
 
   /**
+   * @brief Get asset cache
+   *
+   * @return Asset cache
+   */
+  inline const AssetCache &getCache() const { return mAssetCache; }
+
+  /**
    * @brief Generate preview
    *
    * @param path Original asset path
@@ -178,7 +185,6 @@ public:
    */
   inline RenderStorage &getRenderStorage() { return mRenderStorage; }
 
-private:
   /**
    * @brief Get asset type from path extension
    *
@@ -187,6 +193,7 @@ private:
    */
   static AssetType getAssetTypeFromExtension(const Path &path);
 
+private:
   /**
    * @brief Get hash of a file
    *

--- a/editor/tests/liquidator-tests/asset/AssetManager.test.cpp
+++ b/editor/tests/liquidator-tests/asset/AssetManager.test.cpp
@@ -247,10 +247,12 @@ TEST_P(AssetTest, FailedImportDoesNotDeleteExistingSubdirectories) {
   std::ofstream stream(TempPath / emptyFilename, std::ios::binary);
   stream.close();
 
-  ASSERT_TRUE(
-      manager
-          .importAsset(FixturesPath / validOriginalFilename, InnerPathInAssets)
-          .hasData());
+  {
+    auto res = manager.importAsset(FixturesPath / validOriginalFilename,
+                                   InnerPathInAssets);
+
+    ASSERT_TRUE(res.hasData());
+  }
 
   {
     auto subdirectory = InnerPathInAssets;
@@ -355,6 +357,9 @@ TEST_P(AssetTest, ImportCreatesAssetInCache) {
   EXPECT_TRUE(fs::exists(CachePath / cacheFilename));
   EXPECT_EQ(manager.findEngineAssetPath(AssetsPath / originalFilename),
             CachePath / cacheFilename);
+  EXPECT_EQ(
+      manager.getCache().getTypeFromAssetPath(CachePath / cacheFilename),
+      liquid::editor::AssetManager::getAssetTypeFromExtension(res.getData()));
 }
 
 TEST_P(AssetTest, ImportMirrorsCacheSubdirectoriesWithAssets) {

--- a/engine/src/liquid/asset/AssetCache.h
+++ b/engine/src/liquid/asset/AssetCache.h
@@ -268,6 +268,26 @@ public:
    */
   Result<bool> loadAsset(const Path &path);
 
+  /**
+   * @brief Get type from asset
+   *
+   * @param path Asset path
+   * @return Asset type
+   */
+  AssetType getTypeFromAssetPath(const Path &path) const;
+
+  /**
+   * @brief Create asset metafile
+   *
+   * Creates file in the same path as
+   * the path of the asset
+   *
+   * @param type Asset type
+   * @param path Full path to asset
+   * @return Path to meta file
+   */
+  Result<Path> createMetaFile(AssetType type, Path path);
+
 private:
   /**
    * @brief Get relative path of the asset

--- a/engine/src/liquid/asset/AssetCacheAnimator.cpp
+++ b/engine/src/liquid/asset/AssetCacheAnimator.cpp
@@ -52,11 +52,19 @@ AssetCache::createAnimatorFromAsset(const AssetData<AnimatorAsset> &asset) {
     }
   }
 
-  std::ofstream stream(mAssetsPath / asset.relativePath);
+  auto fullPath = mAssetsPath / asset.relativePath;
+
+  std::ofstream stream(fullPath);
   stream << root;
   stream.close();
 
-  return Result<Path>::Ok(mAssetsPath / asset.relativePath);
+  auto metaRes = createMetaFile(AssetType::Animator, fullPath);
+  if (metaRes.hasError()) {
+    std::filesystem::remove(fullPath);
+    return metaRes;
+  }
+
+  return Result<Path>::Ok(fullPath);
 }
 
 Result<AnimatorAssetHandle>

--- a/engine/src/liquid/asset/AssetCacheTexture.cpp
+++ b/engine/src/liquid/asset/AssetCacheTexture.cpp
@@ -142,6 +142,12 @@ AssetCache::createTextureFromAsset(const AssetData<TextureAsset> &asset) {
     }
   }
 
+  auto metaRes = createMetaFile(AssetType::Texture, assetPath);
+  if (metaRes.hasError()) {
+    std::filesystem::remove(assetPath);
+    return metaRes;
+  }
+
   ktxTexture_Destroy(baseTexture);
 
   return Result<Path>::Ok(assetPath);

--- a/engine/src/liquid/asset/AssetRevision.h
+++ b/engine/src/liquid/asset/AssetRevision.h
@@ -5,18 +5,18 @@
 namespace liquid {
 
 enum class AssetRevision : uint32_t {
-  Material = 230811,
-  Texture = 230811,
-  Mesh = 230811,
-  SkinnedMesh = 230811,
-  Skeleton = 230811,
-  Animation = 230811,
-  Audio = 230811,
-  Prefab = 230811,
-  LuaScript = 230811,
-  Font = 230811,
-  Environment = 230811,
-  Animator = 230811
+  Material = 230911,
+  Texture = 230911,
+  Mesh = 230911,
+  SkinnedMesh = 230911,
+  Skeleton = 230911,
+  Animation = 230911,
+  Audio = 230911,
+  Prefab = 230911,
+  LuaScript = 230911,
+  Font = 230911,
+  Environment = 230911,
+  Animator = 230911
 };
 
 /**

--- a/engine/tests/liquid-tests/asset/AssetCacheAnimation.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheAnimation.test.cpp
@@ -110,6 +110,9 @@ TEST_F(AssetCacheTest, CreatesAnimationFile) {
       EXPECT_EQ(values.at(i), keyframe.keyframeValues.at(i));
     }
   }
+
+  EXPECT_FALSE(std::filesystem::exists(
+      filePath.getData().replace_extension("assetmeta")));
 }
 
 TEST_F(AssetCacheTest, LoadsAnimationAssetFromFile) {

--- a/engine/tests/liquid-tests/asset/AssetCacheAnimator.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheAnimator.test.cpp
@@ -56,13 +56,13 @@ TEST_F(AssetCacheTest, CreatesAnimatorFileFromAsset) {
   asset.data.states.push_back(stateWalk);
   asset.data.states.push_back(stateRun);
 
-  auto res = cache.createAnimatorFromAsset(asset);
+  auto filePath = cache.createAnimatorFromAsset(asset);
 
-  EXPECT_TRUE(res.hasData());
-  EXPECT_FALSE(res.hasError());
-  EXPECT_FALSE(res.hasWarnings());
+  EXPECT_TRUE(filePath.hasData());
+  EXPECT_FALSE(filePath.hasError());
+  EXPECT_FALSE(filePath.hasWarnings());
 
-  auto path = res.getData();
+  auto path = filePath.getData();
 
   std::ifstream stream(path);
   auto node = YAML::Load(stream);
@@ -156,6 +156,12 @@ TEST_F(AssetCacheTest, CreatesAnimatorFileFromAsset) {
     EXPECT_EQ(t2["event"].as<liquid::String>(""), "WALK");
     EXPECT_EQ(t2["target"].as<liquid::String>(""), "walk");
   }
+
+  EXPECT_TRUE(std::filesystem::exists(
+      filePath.getData().replace_extension("assetmeta")));
+  EXPECT_EQ(cache.getTypeFromAssetPath(
+                filePath.getData().replace_extension("assetmeta")),
+            liquid::AssetType::Animator);
 }
 
 TEST_F(AssetCacheTest, LoadAnimatorFailsIfRequiredPropertiesAreInvalid) {

--- a/engine/tests/liquid-tests/asset/AssetCacheEnvironment.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheEnvironment.test.cpp
@@ -40,12 +40,12 @@ TEST_F(AssetCacheTest, CreatesEnvironmentFileFromEnvironmentAsset) {
   asset.data.irradianceMap = irradianceMap;
   asset.data.specularMap = specularMap;
 
-  auto res = cache.createEnvironmentFromAsset(asset);
-  EXPECT_TRUE(res.hasData());
-  EXPECT_FALSE(res.hasError());
-  EXPECT_FALSE(res.hasWarnings());
+  auto filePath = cache.createEnvironmentFromAsset(asset);
+  EXPECT_TRUE(filePath.hasData());
+  EXPECT_FALSE(filePath.hasError());
+  EXPECT_FALSE(filePath.hasWarnings());
 
-  liquid::InputBinaryStream file(res.getData());
+  liquid::InputBinaryStream file(filePath.getData());
   EXPECT_TRUE(file.good());
   liquid::AssetFileHeader header;
   liquid::String magic(liquid::AssetFileMagicLength, '$');
@@ -64,6 +64,9 @@ TEST_F(AssetCacheTest, CreatesEnvironmentFileFromEnvironmentAsset) {
 
   EXPECT_EQ(irradianceMapPath, "test-env/irradiance.ktx");
   EXPECT_EQ(specularMapPath, "test-env/specular.ktx");
+
+  EXPECT_FALSE(std::filesystem::exists(
+      filePath.getData().replace_extension("assetmeta")));
 }
 
 TEST_F(AssetCacheTest,

--- a/engine/tests/liquid-tests/asset/AssetCacheMaterial.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheMaterial.test.cpp
@@ -72,13 +72,13 @@ public:
 
 TEST_F(AssetCacheTest, CreatesMaterialWithTexturesFromAsset) {
   auto asset = createMaterialAsset(true);
-  auto assetFile = cache.createMaterialFromAsset(asset);
+  auto filePath = cache.createMaterialFromAsset(asset);
 
-  EXPECT_FALSE(assetFile.hasError());
-  EXPECT_FALSE(assetFile.hasWarnings());
+  EXPECT_FALSE(filePath.hasError());
+  EXPECT_FALSE(filePath.hasWarnings());
 
   {
-    liquid::InputBinaryStream file(assetFile.getData());
+    liquid::InputBinaryStream file(filePath.getData());
     EXPECT_TRUE(file.good());
 
     liquid::AssetFileHeader header;
@@ -151,16 +151,19 @@ TEST_F(AssetCacheTest, CreatesMaterialWithTexturesFromAsset) {
     EXPECT_EQ(emissiveTextureCoord, 6);
     EXPECT_EQ(emissiveFactor, glm::vec3(0.5f, 0.6f, 2.5f));
   }
+
+  EXPECT_FALSE(std::filesystem::exists(
+      filePath.getData().replace_extension("assetmeta")));
 }
 
 TEST_F(AssetCacheTest,
        CreatesMaterialWithoutTexturesFromAssetIfReferencedTexturesAreInvalid) {
   auto asset = createMaterialAsset(false);
 
-  auto assetFile = cache.createMaterialFromAsset(asset);
+  auto filePath = cache.createMaterialFromAsset(asset);
 
   {
-    liquid::InputBinaryStream file(assetFile.getData());
+    liquid::InputBinaryStream file(filePath.getData());
     EXPECT_TRUE(file.good());
 
     liquid::AssetFileHeader header;

--- a/engine/tests/liquid-tests/asset/AssetCacheMesh.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheMesh.test.cpp
@@ -212,6 +212,9 @@ TEST_F(AssetCacheTest, CreatesMeshFileFromMeshAsset) {
     EXPECT_EQ(materialPath,
               "materials/material-geom-" + std::to_string(i) + ".lqmat");
   }
+
+  EXPECT_FALSE(std::filesystem::exists(
+      filePath.getData().replace_extension("assetmeta")));
 }
 
 TEST_F(AssetCacheTest, DoesNotLoadMeshIfItHasNoVertices) {

--- a/engine/tests/liquid-tests/asset/AssetCachePrefab.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCachePrefab.test.cpp
@@ -468,6 +468,9 @@ TEST_F(AssetCacheTest, CreatesPrefabFile) {
       EXPECT_EQ(asset.data.pointLights.at(i).value.range, range);
     }
   }
+
+  EXPECT_FALSE(std::filesystem::exists(
+      filePath.getData().replace_extension("assetmeta")));
 }
 
 TEST_F(AssetCacheTest, FailsLoadingPrefabIfPrefabHasNoComponents) {

--- a/engine/tests/liquid-tests/asset/AssetCacheSkeleton.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheSkeleton.test.cpp
@@ -105,6 +105,9 @@ TEST_F(AssetCacheTest, CreatesSkeletonFileFromSkeletonAsset) {
               asset.data.jointInverseBindMatrices.at(i));
     EXPECT_EQ(actualNames.at(i), asset.data.jointNames.at(i));
   }
+
+  EXPECT_FALSE(std::filesystem::exists(
+      filePath.getData().replace_extension("assetmeta")));
 }
 
 TEST_F(AssetCacheTest, LoadsSkeletonAssetFromFile) {


### PR DESCRIPTION
- Use metadata to load assets in runtime
- The engine does not care about file extensions