### PR TITLE
Add renderer components

### DIFF
--- a/editor/src/liquidator/actions/EntityMeshActions.h
+++ b/editor/src/liquidator/actions/EntityMeshActions.h
@@ -5,7 +5,15 @@
 
 namespace liquid::editor {
 
+using EntityCreateMesh = EntityDefaultCreateComponent<Mesh>;
+
+using EntitySetMesh = EntityDefaultUpdateComponent<Mesh>;
+
 using EntityDeleteMesh = EntityDefaultDeleteAction<Mesh>;
+
+using EntityCreateSkinnedMesh = EntityDefaultCreateComponent<SkinnedMesh>;
+
+using EntitySetSkinnedMesh = EntityDefaultUpdateComponent<SkinnedMesh>;
 
 using EntityDeleteSkinnedMesh = EntityDefaultDeleteAction<SkinnedMesh>;
 

--- a/editor/src/liquidator/actions/EntityMeshRendererActions.cpp
+++ b/editor/src/liquidator/actions/EntityMeshRendererActions.cpp
@@ -1,0 +1,149 @@
+#include "liquid/core/Base.h"
+#include "EntityMeshRendererActions.h"
+
+namespace liquid::editor {
+
+EntitySetMeshRendererMaterial::EntitySetMeshRendererMaterial(
+    Entity entity, size_t slot, MaterialAssetHandle handle)
+    : mEntity(entity), mSlot(slot), mNewMaterial(handle) {}
+
+ActionExecutorResult
+EntitySetMeshRendererMaterial::onExecute(WorkspaceState &state,
+                                         AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  mOldMaterial =
+      scene.entityDatabase.get<MeshRenderer>(mEntity).materials.at(mSlot);
+  scene.entityDatabase.get<MeshRenderer>(mEntity).materials.at(mSlot) =
+      mNewMaterial;
+
+  ActionExecutorResult result{};
+  result.addToHistory = true;
+  result.entitiesToSave.push_back(mEntity);
+  return result;
+}
+
+ActionExecutorResult
+EntitySetMeshRendererMaterial::onUndo(WorkspaceState &state,
+                                      AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  scene.entityDatabase.get<MeshRenderer>(mEntity).materials.at(mSlot) =
+      mOldMaterial;
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  return result;
+}
+
+bool EntitySetMeshRendererMaterial::predicate(WorkspaceState &state,
+                                              AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  if (!scene.entityDatabase.has<MeshRenderer>(mEntity)) {
+    return false;
+  }
+
+  if (mSlot >=
+      scene.entityDatabase.get<MeshRenderer>(mEntity).materials.size()) {
+    return false;
+  }
+
+  return assetRegistry.getMaterials().hasAsset(mNewMaterial);
+}
+
+EntityAddMeshRendererMaterialSlot::EntityAddMeshRendererMaterialSlot(
+    Entity entity, MaterialAssetHandle handle)
+    : mEntity(entity), mNewMaterial(handle) {}
+
+ActionExecutorResult
+EntityAddMeshRendererMaterialSlot::onExecute(WorkspaceState &state,
+                                             AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  scene.entityDatabase.get<MeshRenderer>(mEntity).materials.push_back(
+      mNewMaterial);
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  result.addToHistory = true;
+  return result;
+}
+
+ActionExecutorResult
+EntityAddMeshRendererMaterialSlot::onUndo(WorkspaceState &state,
+                                          AssetRegistry &assetRegistry) {
+
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  scene.entityDatabase.get<MeshRenderer>(mEntity).materials.pop_back();
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  return result;
+}
+
+bool EntityAddMeshRendererMaterialSlot::predicate(
+    WorkspaceState &state, AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  if (!scene.entityDatabase.has<MeshRenderer>(mEntity)) {
+    return false;
+  }
+
+  return assetRegistry.getMaterials().hasAsset(mNewMaterial);
+}
+
+EntityRemoveLastMeshRendererMaterialSlot::
+    EntityRemoveLastMeshRendererMaterialSlot(Entity entity)
+    : mEntity(entity) {}
+
+ActionExecutorResult EntityRemoveLastMeshRendererMaterialSlot::onExecute(
+    WorkspaceState &state, AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  mOldMaterial =
+      scene.entityDatabase.get<MeshRenderer>(mEntity).materials.back();
+
+  scene.entityDatabase.get<MeshRenderer>(mEntity).materials.pop_back();
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  result.addToHistory = true;
+  return result;
+}
+
+ActionExecutorResult
+EntityRemoveLastMeshRendererMaterialSlot::onUndo(WorkspaceState &state,
+                                                 AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  scene.entityDatabase.get<MeshRenderer>(mEntity).materials.push_back(
+      mOldMaterial);
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  return result;
+}
+
+bool EntityRemoveLastMeshRendererMaterialSlot::predicate(
+    WorkspaceState &state, AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  if (!scene.entityDatabase.has<MeshRenderer>(mEntity)) {
+    return false;
+  }
+
+  return scene.entityDatabase.get<MeshRenderer>(mEntity).materials.size() > 0;
+}
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/EntityMeshRendererActions.h
+++ b/editor/src/liquidator/actions/EntityMeshRendererActions.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "Action.h"
+#include "EntityDefaultDeleteAction.h"
+
+#include "liquid/renderer/MeshRenderer.h"
+
+namespace liquid::editor {
+
+/**
+ * @brief Set material slot for mesh renderer
+ */
+class EntitySetMeshRendererMaterial : public Action {
+public:
+  /**
+   * @brief Create action
+   *
+   * @param entity Entity
+   * @param slot Material slot
+   * @param handle New material
+   */
+  EntitySetMeshRendererMaterial(Entity entity, size_t slot,
+                                MaterialAssetHandle handle);
+
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onExecute(WorkspaceState &state,
+                                 AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action undo
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onUndo(WorkspaceState &state,
+                              AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action predicate
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @retval true Predicate is true
+   * @retval false Predicate is false
+   */
+  bool predicate(WorkspaceState &state, AssetRegistry &assetRegistry) override;
+
+private:
+  Entity mEntity;
+  size_t mSlot;
+  MaterialAssetHandle mOldMaterial = MaterialAssetHandle::Null;
+  MaterialAssetHandle mNewMaterial;
+};
+
+/**
+ * @brief Add new material slot for mesh renderer
+ */
+class EntityAddMeshRendererMaterialSlot : public Action {
+public:
+  /**
+   * @brief Create action
+   *
+   * @param entity Entity
+   * @param handle New material
+   */
+  EntityAddMeshRendererMaterialSlot(Entity entity, MaterialAssetHandle handle);
+
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onExecute(WorkspaceState &state,
+                                 AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action undo
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onUndo(WorkspaceState &state,
+                              AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action predicate
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @retval true Predicate is true
+   * @retval false Predicate is false
+   */
+  bool predicate(WorkspaceState &state, AssetRegistry &assetRegistry) override;
+
+private:
+  Entity mEntity;
+  MaterialAssetHandle mNewMaterial;
+};
+
+/**
+ * @brief Remove last mesh renderer material slot
+ */
+class EntityRemoveLastMeshRendererMaterialSlot : public Action {
+public:
+  /**
+   * @brief Create action
+   *
+   * @param entity Entity
+   */
+  EntityRemoveLastMeshRendererMaterialSlot(Entity entity);
+
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onExecute(WorkspaceState &state,
+                                 AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action undo
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onUndo(WorkspaceState &state,
+                              AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action predicate
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @retval true Predicate is true
+   * @retval false Predicate is false
+   */
+  bool predicate(WorkspaceState &state, AssetRegistry &assetRegistry) override;
+
+private:
+  Entity mEntity;
+  MaterialAssetHandle mOldMaterial = MaterialAssetHandle::Null;
+};
+
+using EntityCreateMeshRenderer = EntityDefaultCreateComponent<MeshRenderer>;
+
+using EntityDeleteMeshRenderer = EntityDefaultDeleteAction<MeshRenderer>;
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/EntitySkinnedMeshRendererActions.cpp
+++ b/editor/src/liquidator/actions/EntitySkinnedMeshRendererActions.cpp
@@ -1,0 +1,150 @@
+#include "liquid/core/Base.h"
+#include "EntitySkinnedMeshRendererActions.h"
+
+namespace liquid::editor {
+
+EntitySetSkinnedMeshRendererMaterial::EntitySetSkinnedMeshRendererMaterial(
+    Entity entity, size_t slot, MaterialAssetHandle handle)
+    : mEntity(entity), mSlot(slot), mNewMaterial(handle) {}
+
+ActionExecutorResult
+EntitySetSkinnedMeshRendererMaterial::onExecute(WorkspaceState &state,
+                                                AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  mOldMaterial =
+      scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.at(
+          mSlot);
+  scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.at(mSlot) =
+      mNewMaterial;
+
+  ActionExecutorResult result{};
+  result.addToHistory = true;
+  result.entitiesToSave.push_back(mEntity);
+  return result;
+}
+
+ActionExecutorResult
+EntitySetSkinnedMeshRendererMaterial::onUndo(WorkspaceState &state,
+                                             AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.at(mSlot) =
+      mOldMaterial;
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  return result;
+}
+
+bool EntitySetSkinnedMeshRendererMaterial::predicate(
+    WorkspaceState &state, AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  if (!scene.entityDatabase.has<SkinnedMeshRenderer>(mEntity)) {
+    return false;
+  }
+
+  if (mSlot >=
+      scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.size()) {
+    return false;
+  }
+
+  return assetRegistry.getMaterials().hasAsset(mNewMaterial);
+}
+
+EntityAddSkinnedMeshRendererMaterialSlot::
+    EntityAddSkinnedMeshRendererMaterialSlot(Entity entity,
+                                             MaterialAssetHandle handle)
+    : mEntity(entity), mNewMaterial(handle) {}
+
+ActionExecutorResult EntityAddSkinnedMeshRendererMaterialSlot::onExecute(
+    WorkspaceState &state, AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.push_back(
+      mNewMaterial);
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  result.addToHistory = true;
+  return result;
+}
+
+ActionExecutorResult
+EntityAddSkinnedMeshRendererMaterialSlot::onUndo(WorkspaceState &state,
+                                                 AssetRegistry &assetRegistry) {
+
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.pop_back();
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  return result;
+}
+
+bool EntityAddSkinnedMeshRendererMaterialSlot::predicate(
+    WorkspaceState &state, AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  if (!scene.entityDatabase.has<SkinnedMeshRenderer>(mEntity)) {
+    return false;
+  }
+
+  return assetRegistry.getMaterials().hasAsset(mNewMaterial);
+}
+
+EntityRemoveLastSkinnedMeshRendererMaterialSlot::
+    EntityRemoveLastSkinnedMeshRendererMaterialSlot(Entity entity)
+    : mEntity(entity) {}
+
+ActionExecutorResult EntityRemoveLastSkinnedMeshRendererMaterialSlot::onExecute(
+    WorkspaceState &state, AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  mOldMaterial =
+      scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.back();
+
+  scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.pop_back();
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  result.addToHistory = true;
+  return result;
+}
+
+ActionExecutorResult EntityRemoveLastSkinnedMeshRendererMaterialSlot::onUndo(
+    WorkspaceState &state, AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.push_back(
+      mOldMaterial);
+
+  ActionExecutorResult result{};
+  result.entitiesToSave.push_back(mEntity);
+  return result;
+}
+
+bool EntityRemoveLastSkinnedMeshRendererMaterialSlot::predicate(
+    WorkspaceState &state, AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  if (!scene.entityDatabase.has<SkinnedMeshRenderer>(mEntity)) {
+    return false;
+  }
+
+  return scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity)
+             .materials.size() > 0;
+}
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/EntitySkinnedMeshRendererActions.h
+++ b/editor/src/liquidator/actions/EntitySkinnedMeshRendererActions.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include "Action.h"
+#include "EntityDefaultDeleteAction.h"
+
+#include "liquid/renderer/SkinnedMeshRenderer.h"
+
+namespace liquid::editor {
+
+/**
+ * @brief Set material slot for skinned mesh renderer
+ */
+class EntitySetSkinnedMeshRendererMaterial : public Action {
+public:
+  /**
+   * @brief Create action
+   *
+   * @param entity Entity
+   * @param slot Material slot
+   * @param handle New material
+   */
+  EntitySetSkinnedMeshRendererMaterial(Entity entity, size_t slot,
+                                       MaterialAssetHandle handle);
+
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onExecute(WorkspaceState &state,
+                                 AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action undo
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onUndo(WorkspaceState &state,
+                              AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action predicate
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @retval true Predicate is true
+   * @retval false Predicate is false
+   */
+  bool predicate(WorkspaceState &state, AssetRegistry &assetRegistry) override;
+
+private:
+  Entity mEntity;
+  size_t mSlot;
+  MaterialAssetHandle mOldMaterial = MaterialAssetHandle::Null;
+  MaterialAssetHandle mNewMaterial;
+};
+
+/**
+ * @brief Add new material slot for skinned mesh renderer
+ */
+class EntityAddSkinnedMeshRendererMaterialSlot : public Action {
+public:
+  /**
+   * @brief Create action
+   *
+   * @param entity Entity
+   * @param handle New material
+   */
+  EntityAddSkinnedMeshRendererMaterialSlot(Entity entity,
+                                           MaterialAssetHandle handle);
+
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onExecute(WorkspaceState &state,
+                                 AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action undo
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onUndo(WorkspaceState &state,
+                              AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action predicate
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @retval true Predicate is true
+   * @retval false Predicate is false
+   */
+  bool predicate(WorkspaceState &state, AssetRegistry &assetRegistry) override;
+
+private:
+  Entity mEntity;
+  MaterialAssetHandle mNewMaterial;
+};
+
+/**
+ * @brief Remove last skinned mesh renderer material slot
+ */
+class EntityRemoveLastSkinnedMeshRendererMaterialSlot : public Action {
+public:
+  /**
+   * @brief Create action
+   *
+   * @param entity Entity
+   */
+  EntityRemoveLastSkinnedMeshRendererMaterialSlot(Entity entity);
+
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onExecute(WorkspaceState &state,
+                                 AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action undo
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onUndo(WorkspaceState &state,
+                              AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action predicate
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @retval true Predicate is true
+   * @retval false Predicate is false
+   */
+  bool predicate(WorkspaceState &state, AssetRegistry &assetRegistry) override;
+
+private:
+  Entity mEntity;
+  MaterialAssetHandle mOldMaterial = MaterialAssetHandle::Null;
+};
+
+using EntityCreateSkinnedMeshRenderer =
+    EntityDefaultCreateComponent<SkinnedMeshRenderer>;
+
+using EntityDeleteSkinnedMeshRenderer =
+    EntityDefaultDeleteAction<SkinnedMeshRenderer>;
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/asset/gltf/PrefabStep.cpp
+++ b/editor/src/liquidator/asset/gltf/PrefabStep.cpp
@@ -85,8 +85,20 @@ void loadPrefabs(GLTFImportData &importData) {
 
     if (hasValidMesh) {
       if (node.skin >= 0) {
-        prefab.data.skinnedMeshes.push_back(
-            {localEntityId, importData.skinnedMeshes.map.at(node.mesh)});
+        auto handle = importData.skinnedMeshes.map.at(node.mesh);
+        const auto &asset =
+            importData.assetCache.getRegistry().getSkinnedMeshes().getAsset(
+                handle);
+
+        std::vector<MaterialAssetHandle> materials;
+        for (const auto &g : asset.data.geometries) {
+          materials.push_back(g.material);
+        }
+
+        prefab.data.skinnedMeshes.push_back({localEntityId, handle});
+
+        SkinnedMeshRenderer renderer{materials};
+        prefab.data.skinnedMeshRenderers.push_back({localEntityId, renderer});
 
         prefab.data.skeletons.push_back(
             {localEntityId,
@@ -98,6 +110,20 @@ void loadPrefabs(GLTFImportData &importData) {
         }
 
       } else {
+        auto handle = importData.meshes.map.at(node.mesh);
+        const auto &asset =
+            importData.assetCache.getRegistry().getMeshes().getAsset(handle);
+
+        std::vector<MaterialAssetHandle> materials;
+        for (const auto &g : asset.data.geometries) {
+          materials.push_back(g.material);
+        }
+
+        prefab.data.meshes.push_back({localEntityId, handle});
+
+        MeshRenderer renderer{materials};
+        prefab.data.meshRenderers.push_back({localEntityId, renderer});
+
         prefab.data.meshes.push_back(
             {localEntityId, importData.meshes.map.at(node.mesh)});
 

--- a/editor/src/liquidator/core/GameExporter.cpp
+++ b/editor/src/liquidator/core/GameExporter.cpp
@@ -25,13 +25,6 @@ void GameExporter::exportGame(const Project &project, const Path &destination) {
                         destination / project.scenesPath.filename(),
                         co::overwrite_existing | co::recursive);
 
-  for (auto &entry :
-       std::filesystem::recursive_directory_iterator(destinationAssetsPath)) {
-    if (entry.path().extension() == ".lqhash") {
-      std::filesystem::remove(entry.path());
-    }
-  }
-
   // Copy engine data
   auto enginePath = Engine::getEnginePath();
   std::filesystem::copy(enginePath, destination / enginePath.filename(),

--- a/editor/src/liquidator/ui/EntityPanel.h
+++ b/editor/src/liquidator/ui/EntityPanel.h
@@ -103,6 +103,26 @@ private:
                   ActionExecutor &actionExecutor);
 
   /**
+   * @brief Render mesh renderer
+   *
+   * @param scene Scene
+   * @param assetRegistry Asset registry
+   * @param actionExecutor Action executor
+   */
+  void renderMeshRenderer(Scene &scene, AssetRegistry &assetRegistry,
+                          ActionExecutor &actionExecutor);
+
+  /**
+   * @brief Render skinned mesh renderer
+   *
+   * @param scene Scene
+   * @param assetRegistry Asset registry
+   * @param actionExecutor Action executor
+   */
+  void renderSkinnedMeshRenderer(Scene &scene, AssetRegistry &assetRegistry,
+                                 ActionExecutor &actionExecutor);
+
+  /**
    * @brief Render animation component
    *
    * @param state Workspace state

--- a/editor/src/liquidator/workspace/Workspace.cpp
+++ b/editor/src/liquidator/workspace/Workspace.cpp
@@ -37,6 +37,7 @@ Workspace::~Workspace() {
   ImGuiIO &io = ImGui::GetIO();
 
   ImGui::SaveIniSettingsToDisk(io.IniFilename);
+  io.IniFilename = nullptr;
   WorkspaceIO::saveWorkspaceState(mState, mState.project.settingsPath /
                                               "state.lqstate");
 }

--- a/editor/tests/liquidator-tests/actions/EntityMeshActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/EntityMeshActions.test.cpp
@@ -5,11 +5,32 @@
 #include "ActionTestBase.h"
 #include "DefaultEntityTests.h"
 
-using EntityDeleteMeshActionTest = ActionTestBase;
+using EntityCreateMeshActionTest = ActionTestBase;
+InitDefaultCreateComponentTests(EntityCreateMeshActionTest, EntityCreateMesh,
+                                Mesh);
+InitActionsTestSuite(EntityActionsTest, EntityCreateMeshActionTest);
 
+using EntityUpdateMeshActionTest = ActionTestBase;
+InitDefaultUpdateComponentTests(EntityUpdateMeshActionTest, EntitySetMesh, Mesh,
+                                handle, liquid::MeshAssetHandle{25});
+InitActionsTestSuite(EntityActionsTest, EntityUpdateMeshActionTest);
+
+using EntityDeleteMeshActionTest = ActionTestBase;
 InitDefaultDeleteComponentTests(EntityDeleteMeshActionTest, EntityDeleteMesh,
                                 Mesh);
 InitActionsTestSuite(EntityActionsTest, EntityDeleteMeshActionTest);
+
+// Skinned mesh
+using EntityCreateSkinnedMeshActionTest = ActionTestBase;
+InitDefaultCreateComponentTests(EntityCreateSkinnedMeshActionTest,
+                                EntityCreateSkinnedMesh, SkinnedMesh);
+InitActionsTestSuite(EntityActionsTest, EntityCreateSkinnedMeshActionTest);
+
+using EntityUpdateSkinnedMeshActionTest = ActionTestBase;
+InitDefaultUpdateComponentTests(EntityUpdateSkinnedMeshActionTest,
+                                EntitySetSkinnedMesh, SkinnedMesh, handle,
+                                liquid::SkinnedMeshAssetHandle{25});
+InitActionsTestSuite(EntityActionsTest, EntityUpdateSkinnedMeshActionTest);
 
 using EntityDeleteSkinnedMeshActionTest = ActionTestBase;
 InitDefaultDeleteComponentTests(EntityDeleteSkinnedMeshActionTest,

--- a/editor/tests/liquidator-tests/actions/EntityMeshRendererActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/EntityMeshRendererActions.test.cpp
@@ -1,0 +1,306 @@
+#include "liquid/core/Base.h"
+#include "liquidator/actions/EntityMeshRendererActions.h"
+
+#include "liquidator-tests/Testing.h"
+#include "ActionTestBase.h"
+#include "DefaultEntityTests.h"
+
+// SetMeshRendererMaterialSlot
+using EntitySetMeshRendererMaterialActionTest = ActionTestBase;
+
+TEST_P(EntitySetMeshRendererMaterialActionTest,
+       ExecutorSetsMaterialInSpecifiedSlot) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::MeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntitySetMeshRendererMaterial action(
+      entity, 1, liquid::MaterialAssetHandle{5});
+  auto res = action.onExecute(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::MeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 2);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{5});
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntitySetMeshRendererMaterialActionTest,
+       UndoSetsPreviousMaterialInSpecifiedSlot) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::MeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntitySetMeshRendererMaterial action(
+      entity, 1, liquid::MaterialAssetHandle{5});
+  action.onExecute(state, assetRegistry);
+  action.onUndo(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::MeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 2);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{2});
+}
+
+TEST_P(EntitySetMeshRendererMaterialActionTest,
+       PredicateReturnsFalseIfNoMeshRendererComponent) {
+  auto entity = activeScene().entityDatabase.create();
+  auto material = assetRegistry.getMaterials().addAsset({});
+  EXPECT_FALSE(
+      liquid::editor::EntitySetMeshRendererMaterial(entity, 0, material)
+          .predicate(state, assetRegistry));
+}
+
+TEST_P(EntitySetMeshRendererMaterialActionTest,
+       PredicateReturnsFalseIfSlotIsBiggerThanExistingSlots) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::MeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  auto material = assetRegistry.getMaterials().addAsset({});
+
+  EXPECT_FALSE(
+      liquid::editor::EntitySetMeshRendererMaterial(entity, 5, material)
+          .predicate(state, assetRegistry));
+}
+
+TEST_P(EntitySetMeshRendererMaterialActionTest,
+       PredicateReturnsFalseIfMaterialDoesNotExist) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::MeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  EXPECT_FALSE(liquid::editor::EntitySetMeshRendererMaterial(
+                   entity, 5, liquid::MaterialAssetHandle{25})
+                   .predicate(state, assetRegistry));
+}
+
+TEST_P(EntitySetMeshRendererMaterialActionTest,
+       PredicateReturnsTrueIfSlotIsValidAndMaterialExists) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::MeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  auto material = assetRegistry.getMaterials().addAsset({});
+
+  EXPECT_TRUE(liquid::editor::EntitySetMeshRendererMaterial(entity, 1, material)
+                  .predicate(state, assetRegistry));
+}
+
+InitActionsTestSuite(EntityActionsTest,
+                     EntitySetMeshRendererMaterialActionTest);
+
+// CreateMeshRendererMaterialSlot
+using EntityAddMeshRendererMaterialSlotActionTest = ActionTestBase;
+
+TEST_P(EntityAddMeshRendererMaterialSlotActionTest,
+       ExecutorCreatesNewSlotInMeshRendererMaterials) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::MeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntityAddMeshRendererMaterialSlot action(
+      entity, liquid::MaterialAssetHandle{5});
+  auto res = action.onExecute(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::MeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 3);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{2});
+  EXPECT_EQ(renderer.materials.at(2), liquid::MaterialAssetHandle{5});
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntityAddMeshRendererMaterialSlotActionTest,
+       UndoRemovesLastSlotFromMeshRendererMaterials) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::MeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntityAddMeshRendererMaterialSlot action(
+      entity, liquid::MaterialAssetHandle{5});
+  action.onExecute(state, assetRegistry);
+  action.onUndo(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::MeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 2);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{2});
+}
+
+TEST_P(EntityAddMeshRendererMaterialSlotActionTest,
+       PredicateReturnsFalseIfNoMeshRenderer) {
+  auto entity = activeScene().entityDatabase.create();
+  auto material = assetRegistry.getMaterials().addAsset({});
+  EXPECT_FALSE(
+      liquid::editor::EntityAddMeshRendererMaterialSlot(entity, material)
+          .predicate(state, assetRegistry));
+}
+
+TEST_P(EntityAddMeshRendererMaterialSlotActionTest,
+       PredicateReturnsFalseIfMaterialDoesNotExist) {
+  auto entity = activeScene().entityDatabase.create();
+
+  liquid::MeshRenderer renderer{};
+  activeScene().entityDatabase.set(entity, renderer);
+
+  EXPECT_FALSE(liquid::editor::EntityAddMeshRendererMaterialSlot(
+                   entity, liquid::MaterialAssetHandle{25})
+                   .predicate(state, assetRegistry));
+}
+
+TEST_P(EntityAddMeshRendererMaterialSlotActionTest,
+       PredicateReturnsTrueIfMaterialExists) {
+  auto entity = activeScene().entityDatabase.create();
+
+  liquid::MeshRenderer renderer{};
+  activeScene().entityDatabase.set(entity, renderer);
+
+  auto material = assetRegistry.getMaterials().addAsset({});
+
+  EXPECT_TRUE(
+      liquid::editor::EntityAddMeshRendererMaterialSlot(entity, material)
+          .predicate(state, assetRegistry));
+}
+
+InitActionsTestSuite(EntityActionsTest,
+                     EntityAddMeshRendererMaterialSlotActionTest);
+
+// EntityRemoveLastMeshRendererMaterialSlot
+using EntityRemoveLastMeshRendererMaterialSlotActionTest = ActionTestBase;
+
+TEST_P(EntityRemoveLastMeshRendererMaterialSlotActionTest,
+       ExecutorRemovesLastSlotFromMeshRenderer) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::MeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntityRemoveLastMeshRendererMaterialSlot action(entity);
+  auto res = action.onExecute(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::MeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 1);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntityRemoveLastMeshRendererMaterialSlotActionTest,
+       UndoAddsLastRemovedMaterialToEnd) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::MeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntityRemoveLastMeshRendererMaterialSlot action(entity);
+  action.onExecute(state, assetRegistry);
+  action.onUndo(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::MeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 2);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{2});
+}
+
+TEST_P(EntityRemoveLastMeshRendererMaterialSlotActionTest,
+       PredicateReturnsFalseIfNoMeshRenderer) {
+  auto entity = activeScene().entityDatabase.create();
+  auto material = assetRegistry.getMaterials().addAsset({});
+  EXPECT_FALSE(liquid::editor::EntityRemoveLastMeshRendererMaterialSlot(entity)
+                   .predicate(state, assetRegistry));
+}
+
+TEST_P(EntityRemoveLastMeshRendererMaterialSlotActionTest,
+       PredicateReturnsFalseIfMeshRendererHasNoMaterialSlots) {
+  auto entity = activeScene().entityDatabase.create();
+  activeScene().entityDatabase.set<liquid::MeshRenderer>(entity, {});
+
+  EXPECT_FALSE(liquid::editor::EntityRemoveLastMeshRendererMaterialSlot(entity)
+                   .predicate(state, assetRegistry));
+}
+
+TEST_P(EntityRemoveLastMeshRendererMaterialSlotActionTest,
+       PredicateReturnsTrueIfMeshRendererHasMaterials) {
+  auto entity = activeScene().entityDatabase.create();
+
+  std::vector<liquid::MaterialAssetHandle> materials{
+      liquid::MaterialAssetHandle{1}};
+  liquid::MeshRenderer renderer{materials};
+  activeScene().entityDatabase.set(entity, renderer);
+
+  EXPECT_TRUE(liquid::editor::EntityRemoveLastMeshRendererMaterialSlot(entity)
+                  .predicate(state, assetRegistry));
+}
+
+InitActionsTestSuite(EntityActionsTest,
+                     EntityRemoveLastMeshRendererMaterialSlotActionTest);
+
+// Default tests
+using EntityCreateMeshRendererActionTest = ActionTestBase;
+InitDefaultCreateComponentTests(EntityCreateMeshRendererActionTest,
+                                EntityCreateMeshRenderer, MeshRenderer);
+InitActionsTestSuite(EntityActionsTest, EntityCreateMeshRendererActionTest);
+
+using EntityDeleteMeshRendererActionTest = ActionTestBase;
+
+InitDefaultDeleteComponentTests(EntityDeleteMeshRendererActionTest,
+                                EntityDeleteMeshRenderer, MeshRenderer);
+InitActionsTestSuite(EntityActionsTest, EntityDeleteMeshRendererActionTest);

--- a/editor/tests/liquidator-tests/actions/EntitySkinnedMeshRendererActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/EntitySkinnedMeshRendererActions.test.cpp
@@ -1,0 +1,317 @@
+#include "liquid/core/Base.h"
+#include "liquidator/actions/EntitySkinnedMeshRendererActions.h"
+
+#include "liquidator-tests/Testing.h"
+#include "ActionTestBase.h"
+#include "DefaultEntityTests.h"
+
+// SetSkinnedMeshRendererMaterialSlot
+using EntitySetSkinnedMeshRendererMaterialActionTest = ActionTestBase;
+
+TEST_P(EntitySetSkinnedMeshRendererMaterialActionTest,
+       ExecutorSetsMaterialInSpecifiedSlot) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::SkinnedMeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntitySetSkinnedMeshRendererMaterial action(
+      entity, 1, liquid::MaterialAssetHandle{5});
+  auto res = action.onExecute(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::SkinnedMeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 2);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{5});
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntitySetSkinnedMeshRendererMaterialActionTest,
+       UndoSetsPreviousMaterialInSpecifiedSlot) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::SkinnedMeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntitySetSkinnedMeshRendererMaterial action(
+      entity, 1, liquid::MaterialAssetHandle{5});
+  action.onExecute(state, assetRegistry);
+  action.onUndo(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::SkinnedMeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 2);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{2});
+}
+
+TEST_P(EntitySetSkinnedMeshRendererMaterialActionTest,
+       PredicateReturnsFalseIfNoSkinnedMeshRendererComponent) {
+  auto entity = activeScene().entityDatabase.create();
+  auto material = assetRegistry.getMaterials().addAsset({});
+  EXPECT_FALSE(
+      liquid::editor::EntitySetSkinnedMeshRendererMaterial(entity, 0, material)
+          .predicate(state, assetRegistry));
+}
+
+TEST_P(EntitySetSkinnedMeshRendererMaterialActionTest,
+       PredicateReturnsFalseIfSlotIsBiggerThanExistingSlots) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::SkinnedMeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  auto material = assetRegistry.getMaterials().addAsset({});
+
+  EXPECT_FALSE(
+      liquid::editor::EntitySetSkinnedMeshRendererMaterial(entity, 5, material)
+          .predicate(state, assetRegistry));
+}
+
+TEST_P(EntitySetSkinnedMeshRendererMaterialActionTest,
+       PredicateReturnsFalseIfMaterialDoesNotExist) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::SkinnedMeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  EXPECT_FALSE(liquid::editor::EntitySetSkinnedMeshRendererMaterial(
+                   entity, 5, liquid::MaterialAssetHandle{25})
+                   .predicate(state, assetRegistry));
+}
+
+TEST_P(EntitySetSkinnedMeshRendererMaterialActionTest,
+       PredicateReturnsTrueIfSlotIsValidAndMaterialExists) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::SkinnedMeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  auto material = assetRegistry.getMaterials().addAsset({});
+
+  EXPECT_TRUE(
+      liquid::editor::EntitySetSkinnedMeshRendererMaterial(entity, 1, material)
+          .predicate(state, assetRegistry));
+}
+
+InitActionsTestSuite(EntityActionsTest,
+                     EntitySetSkinnedMeshRendererMaterialActionTest);
+
+// CreateSkinnedMeshRendererMaterialSlot
+using EntityAddSkinnedMeshRendererMaterialSlotActionTest = ActionTestBase;
+
+TEST_P(EntityAddSkinnedMeshRendererMaterialSlotActionTest,
+       ExecutorCreatesNewSlotInSkinnedMeshRendererMaterials) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::SkinnedMeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntityAddSkinnedMeshRendererMaterialSlot action(
+      entity, liquid::MaterialAssetHandle{5});
+  auto res = action.onExecute(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::SkinnedMeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 3);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{2});
+  EXPECT_EQ(renderer.materials.at(2), liquid::MaterialAssetHandle{5});
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntityAddSkinnedMeshRendererMaterialSlotActionTest,
+       UndoRemovesLastSlotFromSkinnedMeshRendererMaterials) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::SkinnedMeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntityAddSkinnedMeshRendererMaterialSlot action(
+      entity, liquid::MaterialAssetHandle{5});
+  action.onExecute(state, assetRegistry);
+  action.onUndo(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::SkinnedMeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 2);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{2});
+}
+
+TEST_P(EntityAddSkinnedMeshRendererMaterialSlotActionTest,
+       PredicateReturnsFalseIfNoSkinnedMeshRenderer) {
+  auto entity = activeScene().entityDatabase.create();
+  auto material = assetRegistry.getMaterials().addAsset({});
+  EXPECT_FALSE(
+      liquid::editor::EntityAddSkinnedMeshRendererMaterialSlot(entity, material)
+          .predicate(state, assetRegistry));
+}
+
+TEST_P(EntityAddSkinnedMeshRendererMaterialSlotActionTest,
+       PredicateReturnsFalseIfMaterialDoesNotExist) {
+  auto entity = activeScene().entityDatabase.create();
+
+  liquid::SkinnedMeshRenderer renderer{};
+  activeScene().entityDatabase.set(entity, renderer);
+
+  EXPECT_FALSE(liquid::editor::EntityAddSkinnedMeshRendererMaterialSlot(
+                   entity, liquid::MaterialAssetHandle{25})
+                   .predicate(state, assetRegistry));
+}
+
+TEST_P(EntityAddSkinnedMeshRendererMaterialSlotActionTest,
+       PredicateReturnsTrueIfMaterialExists) {
+  auto entity = activeScene().entityDatabase.create();
+
+  liquid::SkinnedMeshRenderer renderer{};
+  activeScene().entityDatabase.set(entity, renderer);
+
+  auto material = assetRegistry.getMaterials().addAsset({});
+
+  EXPECT_TRUE(
+      liquid::editor::EntityAddSkinnedMeshRendererMaterialSlot(entity, material)
+          .predicate(state, assetRegistry));
+}
+
+InitActionsTestSuite(EntityActionsTest,
+                     EntityAddSkinnedMeshRendererMaterialSlotActionTest);
+
+// EntityRemoveLastSkinnedMeshRendererMaterialSlot
+using EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest =
+    ActionTestBase;
+
+TEST_P(EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest,
+       ExecutorRemovesLastSlotFromSkinnedMeshRenderer) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::SkinnedMeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntityRemoveLastSkinnedMeshRendererMaterialSlot action(
+      entity);
+  auto res = action.onExecute(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::SkinnedMeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 1);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest,
+       UndoAddsLastRemovedMaterialToEnd) {
+  auto entity = activeScene().entityDatabase.create();
+
+  {
+    std::vector<liquid::MaterialAssetHandle> materials{
+        liquid::MaterialAssetHandle{1}, liquid::MaterialAssetHandle{2}};
+    liquid::SkinnedMeshRenderer renderer{materials};
+    activeScene().entityDatabase.set(entity, renderer);
+  }
+
+  liquid::editor::EntityRemoveLastSkinnedMeshRendererMaterialSlot action(
+      entity);
+  action.onExecute(state, assetRegistry);
+  action.onUndo(state, assetRegistry);
+
+  const auto &renderer =
+      activeScene().entityDatabase.get<liquid::SkinnedMeshRenderer>(entity);
+
+  EXPECT_EQ(renderer.materials.size(), 2);
+  EXPECT_EQ(renderer.materials.at(0), liquid::MaterialAssetHandle{1});
+  EXPECT_EQ(renderer.materials.at(1), liquid::MaterialAssetHandle{2});
+}
+
+TEST_P(EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest,
+       PredicateReturnsFalseIfNoSkinnedMeshRenderer) {
+  auto entity = activeScene().entityDatabase.create();
+  auto material = assetRegistry.getMaterials().addAsset({});
+  EXPECT_FALSE(
+      liquid::editor::EntityRemoveLastSkinnedMeshRendererMaterialSlot(entity)
+          .predicate(state, assetRegistry));
+}
+
+TEST_P(EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest,
+       PredicateReturnsFalseIfSkinnedMeshRendererHasNoMaterialSlots) {
+  auto entity = activeScene().entityDatabase.create();
+  activeScene().entityDatabase.set<liquid::SkinnedMeshRenderer>(entity, {});
+
+  EXPECT_FALSE(
+      liquid::editor::EntityRemoveLastSkinnedMeshRendererMaterialSlot(entity)
+          .predicate(state, assetRegistry));
+}
+
+TEST_P(EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest,
+       PredicateReturnsTrueIfSkinnedMeshRendererHasMaterials) {
+  auto entity = activeScene().entityDatabase.create();
+
+  std::vector<liquid::MaterialAssetHandle> materials{
+      liquid::MaterialAssetHandle{1}};
+  liquid::SkinnedMeshRenderer renderer{materials};
+  activeScene().entityDatabase.set(entity, renderer);
+
+  EXPECT_TRUE(
+      liquid::editor::EntityRemoveLastSkinnedMeshRendererMaterialSlot(entity)
+          .predicate(state, assetRegistry));
+}
+
+InitActionsTestSuite(EntityActionsTest,
+                     EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest);
+
+// Default tests
+using EntityCreateSkinnedMeshRendererActionTest = ActionTestBase;
+InitDefaultCreateComponentTests(EntityCreateSkinnedMeshRendererActionTest,
+                                EntityCreateSkinnedMeshRenderer,
+                                SkinnedMeshRenderer);
+InitActionsTestSuite(EntityActionsTest,
+                     EntityCreateSkinnedMeshRendererActionTest);
+
+using EntityDeleteSkinnedMeshRendererActionTest = ActionTestBase;
+
+InitDefaultDeleteComponentTests(EntityDeleteSkinnedMeshRendererActionTest,
+                                EntityDeleteSkinnedMeshRenderer,
+                                SkinnedMeshRenderer);
+InitActionsTestSuite(EntityActionsTest,
+                     EntityDeleteSkinnedMeshRendererActionTest);

--- a/engine/assets/shaders/bindless/material.glsl
+++ b/engine/assets/shaders/bindless/material.glsl
@@ -1,0 +1,36 @@
+#ifndef MATERIAL_GLSL
+#define MATERIAL_GLSL
+
+/**
+ * @brief Single material
+ */
+Buffer(16) MaterialItem {
+  uvec4 baseColorTexture;
+  ivec4 baseColorTextureCoord;
+  vec4 baseColorFactor;
+  uvec4 metallicRoughnessTexture;
+  ivec4 metallicRoughnessTextureCoord;
+  vec4 metallicFactor;
+  vec4 roughnessFactor;
+  uvec4 normalTexture;
+  ivec4 normalTextureCoord;
+  vec4 normalScale;
+  uvec4 occlusionTexture;
+  ivec4 occlusionTextureCoord;
+  vec4 occlusionStrength;
+  uvec4 emissiveTexture;
+  ivec4 emissiveTextureCoord;
+  vec3 emissiveFactor;
+};
+
+Buffer(8) MaterialsArray { MaterialItem items[]; };
+
+struct MaterialRangeItem {
+  uint start;
+
+  uint end;
+};
+
+Buffer(8) MaterialRangeArray { MaterialRangeItem items[]; };
+
+#endif

--- a/engine/assets/shaders/geometry.vert
+++ b/engine/assets/shaders/geometry.vert
@@ -10,17 +10,22 @@ layout(location = 5) in vec2 inTextureCoord1;
 layout(location = 0) out vec3 outWorldPosition;
 layout(location = 1) out vec2 outTextureCoord[2];
 layout(location = 3) out mat3 outTBN;
+layout(location = 6) out uint outMaterialIndex;
 
 #include "bindless/base.glsl"
 #include "bindless/mesh.glsl"
 #include "bindless/camera.glsl"
+#include "bindless/material.glsl"
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
 layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
+  MaterialsArray materials;
   TransformsArray meshTransforms;
+  MaterialRangeArray meshMaterialRanges;
   TransformsArray skinnedMeshTransforms;
+  MaterialRangeArray skinnedMeshMaterialRanges;
   SkeletonsArray skeletons;
   Camera camera;
   Empty scene;
@@ -29,6 +34,9 @@ layout(set = 1, binding = 0) uniform DrawParameters {
   Empty shadows;
 }
 uDrawParams;
+
+layout(std430, push_constant) uniform PushConstants { uint submeshIndex; }
+uMeshParams;
 
 void main() {
   mat4 modelMatrix = getMeshTransform(gl_InstanceIndex).modelMatrix;
@@ -46,4 +54,9 @@ void main() {
   outTextureCoord[0] = inTextureCoord0;
   outTextureCoord[1] = inTextureCoord1;
   gl_Position = getCamera().viewProj * worldPosition;
+
+  outMaterialIndex =
+      min(uDrawParams.meshMaterialRanges.items[gl_InstanceIndex].start +
+              uMeshParams.submeshIndex,
+          uDrawParams.meshMaterialRanges.items[gl_InstanceIndex].end);
 }

--- a/engine/assets/shaders/pbr.frag
+++ b/engine/assets/shaders/pbr.frag
@@ -5,6 +5,7 @@
 layout(location = 0) in vec3 inWorldPosition;
 layout(location = 1) in vec2 inTextureCoord[2];
 layout(location = 3) in mat3 inTBN;
+layout(location = 6) in flat uint inMaterialIndex;
 
 layout(location = 0) out vec4 outColor;
 
@@ -13,6 +14,7 @@ layout(location = 0) out vec4 outColor;
 #include "bindless/scene.glsl"
 #include "bindless/shadows.glsl"
 #include "bindless/lights.glsl"
+#include "bindless/material.glsl"
 
 layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
 layout(set = 0, binding = 0) uniform sampler2DArray uTextures2DArray[];
@@ -20,8 +22,11 @@ layout(set = 0, binding = 0) uniform samplerCube uTexturesCube[];
 layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
+  MaterialsArray materials;
   Empty meshTransforms;
+  MaterialRangeArray meshMaterialRanges;
   Empty skinnedMeshTransforms;
+  MaterialRangeArray skinnedMaterialRanges;
   Empty skeletons;
   Camera camera;
   Scene scene;
@@ -30,26 +35,6 @@ layout(set = 1, binding = 0) uniform DrawParameters {
   ShadowMapsArray shadows;
 }
 uDrawParams;
-
-layout(std140, set = 2, binding = 0) uniform MaterialDataRaw {
-  uint baseColorTexture[1];
-  int baseColorTextureCoord[1];
-  vec4 baseColorFactor;
-  uint metallicRoughnessTexture[1];
-  int metallicRoughnessTextureCoord[1];
-  float metallicFactor[1];
-  float roughnessFactor[1];
-  uint normalTexture[1];
-  int normalTextureCoord[1];
-  float normalScale[1];
-  uint occlusionTexture[1];
-  int occlusionTextureCoord[1];
-  float occlusionStrength[1];
-  uint emissiveTexture[1];
-  int emissiveTextureCoord[1];
-  vec3 emissiveFactor;
-}
-uMaterialDataRaw;
 
 /**
  * @brief PBR Material data
@@ -165,17 +150,18 @@ struct MaterialData {
   vec3 emissiveFactor;
 };
 
+#define getMaterial() uDrawParams.materials.items[inMaterialIndex]
+
 MaterialData uMaterialData = MaterialData(
-    uMaterialDataRaw.baseColorTexture[0],
-    uMaterialDataRaw.baseColorTextureCoord[0], uMaterialDataRaw.baseColorFactor,
-    uMaterialDataRaw.metallicRoughnessTexture[0],
-    uMaterialDataRaw.metallicRoughnessTextureCoord[0],
-    uMaterialDataRaw.metallicFactor[0], uMaterialDataRaw.roughnessFactor[0],
-    uMaterialDataRaw.normalTexture[0], uMaterialDataRaw.normalTextureCoord[0],
-    uMaterialDataRaw.normalScale[0], uMaterialDataRaw.occlusionTexture[0],
-    uMaterialDataRaw.occlusionTextureCoord[0],
-    uMaterialDataRaw.occlusionStrength[0], uMaterialDataRaw.emissiveTexture[0],
-    uMaterialDataRaw.emissiveTextureCoord[0], uMaterialDataRaw.emissiveFactor);
+    getMaterial().baseColorTexture[0], getMaterial().baseColorTextureCoord[0],
+    getMaterial().baseColorFactor, getMaterial().metallicRoughnessTexture[0],
+    getMaterial().metallicRoughnessTextureCoord[0],
+    getMaterial().metallicFactor[0], getMaterial().roughnessFactor[0],
+    getMaterial().normalTexture[0], getMaterial().normalTextureCoord[0],
+    getMaterial().normalScale[0], getMaterial().occlusionTexture[0],
+    getMaterial().occlusionTextureCoord[0], getMaterial().occlusionStrength[0],
+    getMaterial().emissiveTexture[0], getMaterial().emissiveTextureCoord[0],
+    getMaterial().emissiveFactor);
 
 const float PI = 3.141592653589793;
 const mat4 DepthBiasMatrix = mat4(0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0,

--- a/engine/src/liquid/asset/AssetCacheAnimation.cpp
+++ b/engine/src/liquid/asset/AssetCacheAnimation.cpp
@@ -55,6 +55,7 @@ AssetCache::loadAnimationDataFromInputStream(InputBinaryStream &stream,
   animation.path = filePath;
   animation.type = AssetType::Animation;
   animation.uuid = filePath.stem().string();
+  animation.name = header.name;
 
   stream.read(animation.data.time);
   uint32_t numKeyframes = 0;

--- a/engine/src/liquid/asset/AssetCacheAnimator.cpp
+++ b/engine/src/liquid/asset/AssetCacheAnimator.cpp
@@ -9,9 +9,8 @@
 
 namespace liquid {
 
-Result<Path>
-liquid::AssetCache::createAnimatorFromSource(const Path &sourcePath,
-                                             const String &uuid) {
+Result<Path> AssetCache::createAnimatorFromSource(const Path &sourcePath,
+                                                  const String &uuid) {
   using co = std::filesystem::copy_options;
 
   auto assetPath = createAssetPath(uuid);

--- a/engine/src/liquid/asset/AssetRegistry.cpp
+++ b/engine/src/liquid/asset/AssetRegistry.cpp
@@ -107,7 +107,8 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
           getTextureFromRegistry(material.emissiveTexture);
       properties.emissiveTextureCoord = material.emissiveTextureCoord;
 
-      material.deviceHandle.reset(new MaterialPBR(properties, renderStorage));
+      material.deviceHandle.reset(
+          new MaterialPBR(asset.name, properties, renderStorage));
     }
   }
 

--- a/engine/src/liquid/asset/AssetRevision.h
+++ b/engine/src/liquid/asset/AssetRevision.h
@@ -12,7 +12,7 @@ enum class AssetRevision : uint32_t {
   Skeleton = 230911,
   Animation = 230911,
   Audio = 230911,
-  Prefab = 230911,
+  Prefab = 230913,
   LuaScript = 230911,
   Font = 230911,
   Environment = 230911,

--- a/engine/src/liquid/asset/PrefabAsset.h
+++ b/engine/src/liquid/asset/PrefabAsset.h
@@ -3,6 +3,8 @@
 #include "liquid/animation/Animator.h"
 #include "liquid/scene/PointLight.h"
 #include "liquid/scene/DirectionalLight.h"
+#include "liquid/renderer/MeshRenderer.h"
+#include "liquid/renderer/SkinnedMeshRenderer.h"
 
 namespace liquid {
 
@@ -100,6 +102,16 @@ struct PrefabAsset {
    * @brief List of entity names
    */
   std::vector<PrefabComponent<String>> names;
+
+  /**
+   * List of mesh renderers
+   */
+  std::vector<PrefabComponent<MeshRenderer>> meshRenderers;
+
+  /**
+   * List of skinned mesh renderers
+   */
+  std::vector<PrefabComponent<SkinnedMeshRenderer>> skinnedMeshRenderers;
 };
 
 } // namespace liquid

--- a/engine/src/liquid/entity/EntityDatabase.cpp
+++ b/engine/src/liquid/entity/EntityDatabase.cpp
@@ -37,6 +37,8 @@ EntityDatabase::EntityDatabase() {
   reg<RigidBodyClear>();
   reg<Script>();
   reg<Text>();
+  reg<MeshRenderer>();
+  reg<SkinnedMeshRenderer>();
 }
 
 } // namespace liquid

--- a/engine/src/liquid/entity/EntityDatabase.h
+++ b/engine/src/liquid/entity/EntityDatabase.h
@@ -35,6 +35,8 @@
 #include "liquid/physics/PhysxInstance.h"
 #include "liquid/scripting/Script.h"
 #include "liquid/text/Text.h"
+#include "liquid/renderer/MeshRenderer.h"
+#include "liquid/renderer/SkinnedMeshRenderer.h"
 
 namespace liquid {
 

--- a/engine/src/liquid/entity/EntitySpawner.cpp
+++ b/engine/src/liquid/entity/EntitySpawner.cpp
@@ -78,9 +78,19 @@ std::vector<Entity> EntitySpawner::spawnPrefab(PrefabAssetHandle handle,
     mEntityDatabase.set<Mesh>(entity, {pMesh.value});
   }
 
+  for (const auto &pRenderer : asset.meshRenderers) {
+    auto entity = getOrCreateEntity(pRenderer.entity);
+    mEntityDatabase.set(entity, pRenderer.value);
+  }
+
   for (const auto &pSkinnedMesh : asset.skinnedMeshes) {
     auto entity = getOrCreateEntity(pSkinnedMesh.entity);
     mEntityDatabase.set<SkinnedMesh>(entity, {pSkinnedMesh.value});
+  }
+
+  for (const auto &pRenderer : asset.skinnedMeshRenderers) {
+    auto entity = getOrCreateEntity(pRenderer.entity);
+    mEntityDatabase.set(entity, pRenderer.value);
   }
 
   for (const auto &pSkeleton : asset.skeletons) {

--- a/engine/src/liquid/renderer/Material.cpp
+++ b/engine/src/liquid/renderer/Material.cpp
@@ -4,7 +4,8 @@
 
 namespace liquid {
 
-Material::Material(const std::vector<rhi::TextureHandle> &textures,
+Material::Material(const String &name,
+                   const std::vector<rhi::TextureHandle> &textures,
                    const std::vector<std::pair<String, Property>> &properties,
                    RenderStorage &renderStorage)
     : mTextures(textures) {
@@ -17,9 +18,9 @@ Material::Material(const std::vector<rhi::TextureHandle> &textures,
 
   if (!mProperties.empty()) {
     auto size = updateBufferData();
-    mBuffer =
-        renderStorage.createBuffer({rhi::BufferUsage::Uniform, size, mData});
-    mDescriptor = renderStorage.createMaterialDescriptor(mBuffer);
+    rhi::BufferDescription desc{rhi::BufferUsage::Uniform, size, mData};
+    desc.debugName = name;
+    mBuffer = renderStorage.createBuffer(desc);
   }
 }
 

--- a/engine/src/liquid/renderer/Material.h
+++ b/engine/src/liquid/renderer/Material.h
@@ -16,11 +16,12 @@ public:
   /**
    * @brief Creates material
    *
+   * @param name Material name
    * @param textures Textures
    * @param properties Material properties
    * @param renderStorage Render storage
    */
-  Material(const std::vector<rhi::TextureHandle> &textures,
+  Material(const String &name, const std::vector<rhi::TextureHandle> &textures,
            const std::vector<std::pair<String, Property>> &properties,
            RenderStorage &renderStorage);
 
@@ -57,6 +58,13 @@ public:
   inline rhi::BufferHandle getBuffer() const { return mBuffer.getHandle(); }
 
   /**
+   * @brief Get buffer address
+   *
+   * @return Buffer device address
+   */
+  inline rhi::DeviceAddress getAddress() const { return mBuffer.getAddress(); }
+
+  /**
    * @brief Get properties
    *
    * @return Unordered list of properties
@@ -64,13 +72,6 @@ public:
   inline const std::vector<Property> &getProperties() const {
     return mProperties;
   }
-
-  /**
-   * @brief Get descriptor
-   *
-   * @return rhi::Descriptor
-   */
-  inline const rhi::Descriptor &getDescriptor() const { return mDescriptor; }
 
 private:
   /**
@@ -87,8 +88,6 @@ private:
   rhi::Buffer mBuffer;
 
   char *mData = nullptr;
-
-  rhi::Descriptor mDescriptor;
 
   std::vector<Property> mProperties;
   std::map<String, size_t> mPropertyMap;

--- a/engine/src/liquid/renderer/MaterialPBR.cpp
+++ b/engine/src/liquid/renderer/MaterialPBR.cpp
@@ -50,9 +50,9 @@ MaterialPBR::Properties::getProperties() const {
           {"emissiveFactor", emissiveFactor}};
 }
 
-MaterialPBR::MaterialPBR(const Properties &properties,
+MaterialPBR::MaterialPBR(const String &name, const Properties &properties,
                          RenderStorage &renderStorage)
-    : Material(properties.getTextures(), properties.getProperties(),
+    : Material(name, properties.getTextures(), properties.getProperties(),
                renderStorage) {}
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/MaterialPBR.h
+++ b/engine/src/liquid/renderer/MaterialPBR.h
@@ -114,10 +114,12 @@ public:
   /**
    * @brief Create PBR material
    *
+   * @param name Material name
    * @param properties PBR properties
    * @param renderStorage Render storage
    */
-  MaterialPBR(const Properties &properties, RenderStorage &renderStorage);
+  MaterialPBR(const String &name, const Properties &properties,
+              RenderStorage &renderStorage);
 };
 
 } // namespace liquid

--- a/engine/src/liquid/renderer/MeshRenderer.h
+++ b/engine/src/liquid/renderer/MeshRenderer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace liquid {
+
+/**
+ * @brief Mesh renderer component
+ *
+ * Used to render meshes
+ */
+struct MeshRenderer {
+  /**
+   * Materials
+   */
+  std::vector<MaterialAssetHandle> materials;
+};
+
+} // namespace liquid

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -103,23 +103,20 @@ private:
    *
    * @param commandList Command list
    * @param pipeline Pipeline handle
-   * @param bindMaterialData Bind material data
    * @param frameIndex Frame index
    */
   void render(rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline,
-              bool bindMaterialData, uint32_t frameIndex);
+              uint32_t frameIndex);
 
   /**
    * @brief Render skinned meshes
    *
    * @param commandList Command list
    * @param pipeline Pipeline handle
-   * @param bindMaterialData Bind material data
    * @param frameIndex Frame index
    */
   void renderSkinned(rhi::RenderCommandList &commandList,
-                     rhi::PipelineHandle pipeline, bool bindMaterialData,
-                     uint32_t frameIndex);
+                     rhi::PipelineHandle pipeline, uint32_t frameIndex);
 
   /**
    * @brief Render texts

--- a/engine/src/liquid/renderer/SceneRendererFrameData.h
+++ b/engine/src/liquid/renderer/SceneRendererFrameData.h
@@ -163,6 +163,21 @@ public:
   };
 
   /**
+   * @brief Material range
+   */
+  struct MaterialRange {
+    /**
+     * Range start
+     */
+    uint32_t start = 0;
+
+    /**
+     * Range end
+     */
+    uint32_t end = 0;
+  };
+
+  /**
    * @brief Mesh data
    */
   struct MeshData {
@@ -171,6 +186,11 @@ public:
      * @brief Transforms of mesh entities
      */
     std::vector<glm::mat4> transforms;
+
+    /**
+     * @brief Mateiral ranges
+     */
+    std::vector<MaterialRange> materialRanges;
 
     /**
      * @brief Ids of mesh entities
@@ -320,21 +340,23 @@ public:
   inline const size_t getNumShadowMaps() const { return mShadowMaps.size(); }
 
   /**
+   * @brief Set default material
+   *
+   * @param material Default material
+   */
+  void setDefaultMaterial(rhi::DeviceAddress material);
+
+  /**
    * @brief Add mesh data
    *
    * @param handle Mesh handle
    * @param entity Entity
    * @param transform Mesh world transform
+   * @param materials Materials
    */
   void addMesh(MeshAssetHandle handle, liquid::Entity entity,
-               const glm::mat4 &transform);
-
-  /**
-   * @brief Set BRDF lookup table
-   *
-   * @param brdfLut BRDF Lookup table
-   */
-  void setBrdfLookupTable(rhi::TextureHandle brdfLut);
+               const glm::mat4 &transform,
+               const std::vector<rhi::DeviceAddress> &materials);
 
   /**
    * @brief Add skinned mesh data
@@ -343,10 +365,19 @@ public:
    * @param entity Entity
    * @param transform Skinned mesh world transform
    * @param skeleton Skeleton joint transforms
+   * @param materials Materials
    */
   void addSkinnedMesh(SkinnedMeshAssetHandle handle, Entity entity,
                       const glm::mat4 &transform,
-                      const std::vector<glm::mat4> &skeleton);
+                      const std::vector<glm::mat4> &skeleton,
+                      const std::vector<rhi::DeviceAddress> &materials);
+
+  /**
+   * @brief Set BRDF lookup table
+   *
+   * @param brdfLut BRDF Lookup table
+   */
+  void setBrdfLookupTable(rhi::TextureHandle brdfLut);
 
   /**
    * @brief Add directional light
@@ -486,6 +517,15 @@ public:
   }
 
   /**
+   * @brief Get flattened materials
+   *
+   * @return Flattened materials buffers
+   */
+  inline rhi::DeviceAddress getFlattenedMaterialsBuffer() const {
+    return mFlatMaterialsBuffer.getAddress();
+  }
+
+  /**
    * @brief Get mesh transforms buffer
    *
    * @return Mesh transforms buffer
@@ -495,12 +535,30 @@ public:
   }
 
   /**
+   * @brief Get mesh materials buffer
+   *
+   * @return Mesh materials buffer
+   */
+  inline rhi::DeviceAddress getMeshMaterialsBuffer() const {
+    return mMeshMaterialsBuffer.getAddress();
+  }
+
+  /**
    * @brief Get skinned mesh transforms buffer
    *
    * @return Skinned mesh transforms buffer
    */
   inline rhi::DeviceAddress getSkinnedMeshTransformsBuffer() const {
     return mSkinnedMeshTransformsBuffer.getAddress();
+  }
+
+  /**
+   * @brief Get skinned mesh materials buffer
+   *
+   * @return Skinned mesh materials buffer
+   */
+  inline rhi::DeviceAddress getSkinnedMeshMaterialsBuffer() const {
+    return mSkinnedMeshMaterialsBuffer.getAddress();
   }
 
   /**
@@ -605,19 +663,24 @@ private:
 
   size_t mLastSkeleton = 0;
 
+  std::vector<rhi::DeviceAddress> mFlatMaterials;
+  rhi::Buffer mFlatMaterialsBuffer;
+
   rhi::Buffer mMeshTransformsBuffer;
   rhi::Buffer mSkinnedMeshTransformsBuffer;
   rhi::Buffer mSkeletonsBuffer;
+  rhi::Buffer mMeshMaterialsBuffer;
+  rhi::Buffer mSkinnedMeshMaterialsBuffer;
+  std::unordered_map<MeshAssetHandle, MeshData> mMeshGroups;
+  std::unordered_map<SkinnedMeshAssetHandle, SkinnedMeshData>
+      mSkinnedMeshGroups;
+
   rhi::Buffer mSceneBuffer;
   rhi::Buffer mDirectionalLightsBuffer;
   rhi::Buffer mPointLightsBuffer;
   rhi::Buffer mShadowMapsBuffer;
   rhi::Buffer mCameraBuffer;
   rhi::Buffer mSkyboxBuffer;
-
-  std::unordered_map<MeshAssetHandle, MeshData> mMeshGroups;
-  std::unordered_map<SkinnedMeshAssetHandle, SkinnedMeshData>
-      mSkinnedMeshGroups;
 
   std::vector<glm::mat4> mSpriteTransforms;
   std::vector<rhi::TextureHandle> mSpriteTextures;

--- a/engine/src/liquid/renderer/SkinnedMeshRenderer.h
+++ b/engine/src/liquid/renderer/SkinnedMeshRenderer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace liquid {
+
+/**
+ * @brief Skinned mesh renderer component
+ *
+ * Used to render skinned meshes
+ */
+struct SkinnedMeshRenderer {
+  /**
+   * Materials
+   */
+  std::vector<MaterialAssetHandle> materials;
+};
+
+} // namespace liquid

--- a/engine/src/liquid/scene/private/EntitySerializer.cpp
+++ b/engine/src/liquid/scene/private/EntitySerializer.cpp
@@ -163,12 +163,40 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
     }
   }
 
+  if (mEntityDatabase.has<MeshRenderer>(entity)) {
+    const auto &renderer = mEntityDatabase.get<MeshRenderer>(entity);
+
+    components["meshRenderer"]["materials"] =
+        YAML::Node(YAML::NodeType::Sequence);
+
+    for (auto material : renderer.materials) {
+      if (mAssetRegistry.getMaterials().hasAsset(material)) {
+        auto uuid = mAssetRegistry.getMaterials().getAsset(material).uuid;
+        components["meshRenderer"]["materials"].push_back(uuid);
+      }
+    }
+  }
+
   if (mEntityDatabase.has<SkinnedMesh>(entity)) {
     auto handle = mEntityDatabase.get<SkinnedMesh>(entity).handle;
     if (mAssetRegistry.getSkinnedMeshes().hasAsset(handle)) {
       auto uuid = mAssetRegistry.getSkinnedMeshes().getAsset(handle).uuid;
 
       components["skinnedMesh"] = uuid;
+    }
+  }
+
+  if (mEntityDatabase.has<SkinnedMeshRenderer>(entity)) {
+    const auto &renderer = mEntityDatabase.get<SkinnedMeshRenderer>(entity);
+
+    components["skinnedMeshRenderer"]["materials"] =
+        YAML::Node(YAML::NodeType::Sequence);
+
+    for (auto material : renderer.materials) {
+      if (mAssetRegistry.getMaterials().hasAsset(material)) {
+        auto uuid = mAssetRegistry.getMaterials().getAsset(material).uuid;
+        components["skinnedMeshRenderer"]["materials"].push_back(uuid);
+      }
     }
   }
 

--- a/engine/src/liquid/scene/private/SceneLoader.cpp
+++ b/engine/src/liquid/scene/private/SceneLoader.cpp
@@ -144,6 +144,26 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
     }
   }
 
+  if (node["components"]["meshRenderer"] &&
+      node["components"]["meshRenderer"].IsMap()) {
+    MeshRenderer renderer{};
+    auto materials = node["components"]["meshRenderer"]["materials"];
+
+    if (materials.IsSequence()) {
+      for (auto material : materials) {
+        auto uuid = material.as<String>("");
+        auto handle = mAssetRegistry.getMaterials().findHandleByUuid(uuid);
+        if (handle == MaterialAssetHandle::Null) {
+          continue;
+        }
+
+        renderer.materials.push_back(handle);
+      }
+    }
+
+    mEntityDatabase.set(entity, renderer);
+  }
+
   if (node["components"]["skinnedMesh"]) {
     auto uuid = node["components"]["skinnedMesh"].as<String>("");
     auto handle = mAssetRegistry.getSkinnedMeshes().findHandleByUuid(uuid);
@@ -151,6 +171,26 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
     if (handle != SkinnedMeshAssetHandle::Null) {
       mEntityDatabase.set<SkinnedMesh>(entity, {handle});
     }
+  }
+
+  if (node["components"]["skinnedMeshRenderer"] &&
+      node["components"]["skinnedMeshRenderer"].IsMap()) {
+    SkinnedMeshRenderer renderer{};
+    auto materials = node["components"]["skinnedMeshRenderer"]["materials"];
+
+    if (materials.IsSequence()) {
+      for (auto material : materials) {
+        auto uuid = material.as<String>("");
+        auto handle = mAssetRegistry.getMaterials().findHandleByUuid(uuid);
+        if (handle == MaterialAssetHandle::Null) {
+          continue;
+        }
+
+        renderer.materials.push_back(handle);
+      }
+    }
+
+    mEntityDatabase.set(entity, renderer);
   }
 
   if (node["components"]["skeleton"]) {

--- a/engine/tests/liquid-tests/asset/AssetCacheAnimation.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheAnimation.test.cpp
@@ -119,6 +119,7 @@ TEST_F(AssetCacheAnimationTest, LoadsAnimationAssetFromFile) {
   EXPECT_NE(handle.getData(), liquid::AnimationAssetHandle::Null);
 
   auto &actual = cache.getRegistry().getAnimations().getAsset(handle.getData());
+  EXPECT_EQ(actual.name, asset.name);
   EXPECT_EQ(actual.type, liquid::AssetType::Animation);
 
   EXPECT_EQ(actual.data.time, asset.data.time);

--- a/engine/tests/liquid-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/liquid-tests/entity/EntitySpawner.test.cpp
@@ -63,6 +63,25 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
     asset.data.meshes.push_back(mesh);
   }
 
+  // Create two mesh renderers with 3 materials each
+  for (uint32_t i = 0; i < 2; ++i) {
+    liquid::PrefabComponent<liquid::MeshRenderer> renderer{};
+    renderer.entity = i;
+    renderer.value.materials.push_back(liquid::MaterialAssetHandle{1});
+    renderer.value.materials.push_back(liquid::MaterialAssetHandle{2});
+    renderer.value.materials.push_back(liquid::MaterialAssetHandle{3});
+    asset.data.meshRenderers.push_back(renderer);
+  }
+
+  // Create three skinned mesh renderers with 2 materials each
+  for (uint32_t i = 0; i < 3; ++i) {
+    liquid::PrefabComponent<liquid::SkinnedMeshRenderer> renderer{};
+    renderer.entity = i;
+    renderer.value.materials.push_back(liquid::MaterialAssetHandle{1});
+    renderer.value.materials.push_back(liquid::MaterialAssetHandle{2});
+    asset.data.skinnedMeshRenderers.push_back(renderer);
+  }
+
   // Create names
   for (uint32_t i = 3; i < 5; ++i) {
     liquid::PrefabComponent<liquid::String> name{};
@@ -187,12 +206,34 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
     EXPECT_EQ(mesh.handle, static_cast<liquid::MeshAssetHandle>(i));
   }
 
+  // Test mesh renderers
+  for (uint32_t i = 0; i < 2; ++i) {
+    auto entity = res.at(i);
+    const auto &renderer = db.get<liquid::MeshRenderer>(entity);
+
+    for (size_t mi = 0; mi < renderer.materials.size(); ++mi) {
+      EXPECT_EQ(renderer.materials.at(mi),
+                static_cast<liquid::MaterialAssetHandle>(mi + 1));
+    }
+  }
+
   // Test skinned meshes
   for (uint32_t i = 2; i < 5; ++i) {
     auto entity = res.at(i);
 
     const auto &mesh = db.get<liquid::SkinnedMesh>(entity);
     EXPECT_EQ(mesh.handle, static_cast<liquid::SkinnedMeshAssetHandle>(i));
+  }
+
+  // Test skinned mesh renderer
+  for (uint32_t i = 0; i < 3; ++i) {
+    auto entity = res.at(i);
+    const auto &renderer = db.get<liquid::SkinnedMeshRenderer>(entity);
+
+    for (size_t mi = 0; mi < renderer.materials.size(); ++mi) {
+      EXPECT_EQ(renderer.materials.at(mi),
+                static_cast<liquid::MaterialAssetHandle>(mi + 1));
+    }
   }
 
   // Test skeletons

--- a/engine/tests/liquid-tests/renderer/Material.test.cpp
+++ b/engine/tests/liquid-tests/renderer/Material.test.cpp
@@ -17,7 +17,7 @@ TEST_F(MaterialTest, SetsBuffersAndTextures) {
       liquid::rhi::TextureHandle(1)};
 
   liquid::Material material(
-      textures,
+      "test", textures,
       {
           {"specular", liquid::Property(glm::vec3(0.5, 0.2, 0.3))},
           {"diffuse", liquid::Property(glm::vec4(1.0, 1.0, 1.0, 1.0))},
@@ -44,7 +44,7 @@ TEST_F(MaterialTest, DoesNotCreateBuffersIfEmptyProperties) {
   std::vector<liquid::rhi::TextureHandle> textures{
       liquid::rhi::TextureHandle(1)};
 
-  liquid::Material material(textures, {}, renderStorage);
+  liquid::Material material("test", textures, {}, renderStorage);
 
   EXPECT_EQ(material.getTextures(), textures);
   EXPECT_EQ(material.hasTextures(), true);
@@ -52,7 +52,7 @@ TEST_F(MaterialTest, DoesNotCreateBuffersIfEmptyProperties) {
 }
 
 TEST_F(MaterialTest, DoesNotSetTexturesIfNoTexture) {
-  liquid::Material material({}, {}, renderStorage);
+  liquid::Material material("test", {}, {}, renderStorage);
 
   EXPECT_EQ(material.getTextures().size(), 0);
   EXPECT_EQ(material.hasTextures(), false);
@@ -63,7 +63,7 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfPropertyDoesNotExist) {
   glm::vec3 testVec3{1.0f, 0.2f, 3.6f};
   float testReal = 45.0f;
 
-  liquid::Material material({},
+  liquid::Material material("test", {},
                             {
                                 {"specular", liquid::Property(testVec3)},
                                 {"diffuse", liquid::Property(testReal)},
@@ -106,7 +106,7 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfNewPropertyTypeIsDifferent) {
   glm::vec3 testVec3{1.0f, 0.2f, 3.6f};
   float testReal = 45.0f;
 
-  liquid::Material material({},
+  liquid::Material material("test", {},
                             {
                                 {"specular", liquid::Property(testVec3)},
                                 {"diffuse", liquid::Property(testReal)},
@@ -149,7 +149,7 @@ TEST_F(MaterialTest, UpdatesPropertyIfNameAndTypeMatch) {
   glm::vec3 testVec3{1.0f, 0.2f, 3.6f};
   float testReal = 45.0f;
 
-  liquid::Material material({},
+  liquid::Material material("test", {},
                             {
                                 {"specular", liquid::Property(testVec3)},
                                 {"diffuse", liquid::Property(testReal)},

--- a/engine/tests/liquid-tests/renderer/MaterialPBR.test.cpp
+++ b/engine/tests/liquid-tests/renderer/MaterialPBR.test.cpp
@@ -137,7 +137,7 @@ TEST_F(MaterialPBRTest, SetsShadersPropertiesAndTextures) {
                                              0,
                                              glm::vec3(1.0f, 0.2f, 0.4f)};
 
-  liquid::MaterialPBR material(properties, renderStorage);
+  liquid::MaterialPBR material("test", properties, renderStorage);
 
   auto *buffer = device.getBuffer(material.getBuffer());
 


### PR DESCRIPTION
- Add mesh renderer component
- Add skinned mesh renderer component
- Add renderer components to prefab
- Store materials in renderer components
- Save/write renderer components in scene file
- Add editor actions for renderers
- Add UI to CRUD renderers
- Add UI to modify material slots of renderer
- Use materials in renderers in PBR
- Use default material if renderer material is not provided
- Remove binding materials in PBR renderer
- Add renderer components when spawning prefabs
- Create renderers when importing GLTF
- Fix prefab view in asset browser
- Fix export issue due to invaild Imgui file save on close