### PR TITLE
Mesh skinned mesh and mesh asset maps

### DIFF
--- a/editor/src/liquidator/actions/EntityMeshActions.cpp
+++ b/editor/src/liquidator/actions/EntityMeshActions.cpp
@@ -1,4 +1,132 @@
 #include "liquid/core/Base.h"
 #include "EntityMeshActions.h"
 
-namespace liquid::editor {} // namespace liquid::editor
+namespace liquid::editor {
+
+/**
+ * @brief Replace mesh with new one
+ *
+ * @param type Mesh asset type
+ * @param mesh Mesh asset handle
+ * @param entity Entity
+ * @param db Entity database
+ */
+static void replaceMesh(AssetType type, MeshAssetHandle mesh, Entity entity,
+                        EntityDatabase &db) {
+  if (type == AssetType::Mesh) {
+    db.set<Mesh>(entity, {mesh});
+
+    if (db.has<SkinnedMesh>(entity)) {
+      db.remove<SkinnedMesh>(entity);
+    }
+  } else if (type == AssetType::SkinnedMesh) {
+    db.set<SkinnedMesh>(entity, {mesh});
+
+    if (db.has<Mesh>(entity)) {
+      db.remove<Mesh>(entity);
+    }
+  }
+}
+
+EntitySetMesh::EntitySetMesh(Entity entity, MeshAssetHandle mesh)
+    : mEntity(entity), mMesh(mesh) {}
+
+ActionExecutorResult EntitySetMesh::onExecute(WorkspaceState &state,
+                                              AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  auto &db = scene.entityDatabase;
+
+  if (db.has<Mesh>(mEntity)) {
+    mOldMesh = db.get<Mesh>(mEntity).handle;
+  } else if (db.has<SkinnedMesh>(mEntity)) {
+    mOldMesh = db.get<SkinnedMesh>(mEntity).handle;
+  }
+
+  auto type = assetRegistry.getMeshes().getAsset(mMesh).type;
+  replaceMesh(type, mMesh, mEntity, db);
+
+  ActionExecutorResult res;
+  res.entitiesToSave.push_back(mEntity);
+  res.addToHistory = true;
+
+  return res;
+}
+
+ActionExecutorResult EntitySetMesh::onUndo(WorkspaceState &state,
+                                           AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+  auto &db = scene.entityDatabase;
+
+  if (mOldMesh != MeshAssetHandle::Null) {
+    auto type = assetRegistry.getMeshes().getAsset(mOldMesh).type;
+    replaceMesh(type, mOldMesh, mEntity, db);
+  } else {
+    if (db.has<Mesh>(mEntity)) {
+      db.remove<Mesh>(mEntity);
+    } else if (db.has<SkinnedMesh>(mEntity)) {
+      db.remove<SkinnedMesh>(mEntity);
+    }
+  }
+
+  ActionExecutorResult res;
+  res.entitiesToSave.push_back(mEntity);
+
+  return res;
+}
+
+bool EntitySetMesh::predicate(WorkspaceState &state,
+                              AssetRegistry &assetRegistry) {
+  return assetRegistry.getMeshes().hasAsset(mMesh);
+}
+
+EntityDeleteMesh::EntityDeleteMesh(Entity entity) : mEntity(entity) {}
+
+ActionExecutorResult EntityDeleteMesh::onExecute(WorkspaceState &state,
+                                                 AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+  auto &db = scene.entityDatabase;
+
+  if (db.has<Mesh>(mEntity)) {
+    mOldMesh = db.get<Mesh>(mEntity).handle;
+    db.remove<Mesh>(mEntity);
+  } else if (db.has<SkinnedMesh>(mEntity)) {
+    mOldMesh = db.get<SkinnedMesh>(mEntity).handle;
+    db.remove<SkinnedMesh>(mEntity);
+  }
+
+  ActionExecutorResult res;
+  res.entitiesToSave.push_back(mEntity);
+  res.addToHistory = true;
+
+  return res;
+}
+
+ActionExecutorResult EntityDeleteMesh::onUndo(WorkspaceState &state,
+                                              AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+  auto &db = scene.entityDatabase;
+  auto type = assetRegistry.getMeshes().getAsset(mOldMesh).type;
+
+  replaceMesh(type, mOldMesh, mEntity, db);
+
+  ActionExecutorResult res;
+  res.entitiesToSave.push_back(mEntity);
+
+  return res;
+}
+
+bool EntityDeleteMesh::predicate(WorkspaceState &state,
+                                 AssetRegistry &assetRegistry) {
+  auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
+                                                        : state.scene;
+
+  return scene.entityDatabase.has<liquid::Mesh>(mEntity) ||
+         scene.entityDatabase.has<liquid::SkinnedMesh>(mEntity);
+}
+
+} // namespace liquid::editor

--- a/editor/src/liquidator/actions/EntityMeshActions.h
+++ b/editor/src/liquidator/actions/EntityMeshActions.h
@@ -5,16 +5,100 @@
 
 namespace liquid::editor {
 
-using EntityCreateMesh = EntityDefaultCreateComponent<Mesh>;
+/**
+ * @brief Create or update entity mesh action
+ */
+class EntitySetMesh : public Action {
+public:
+  /**
+   * @brief Set mesh for entity
+   *
+   * @param entity Entity mesh
+   * @param mesh Mesh handle
+   */
+  EntitySetMesh(Entity entity, MeshAssetHandle mesh);
 
-using EntitySetMesh = EntityDefaultUpdateComponent<Mesh>;
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onExecute(WorkspaceState &state,
+                                 AssetRegistry &assetRegistry) override;
 
-using EntityDeleteMesh = EntityDefaultDeleteAction<Mesh>;
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onUndo(WorkspaceState &state,
+                              AssetRegistry &assetRegistry) override;
 
-using EntityCreateSkinnedMesh = EntityDefaultCreateComponent<SkinnedMesh>;
+  /**
+   * @brief Action predicate
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @retval true Predicate is true
+   * @retval false Predicate is false
+   */
+  bool predicate(WorkspaceState &state, AssetRegistry &assetRegistry) override;
 
-using EntitySetSkinnedMesh = EntityDefaultUpdateComponent<SkinnedMesh>;
+private:
+  Entity mEntity;
+  MeshAssetHandle mMesh;
+  MeshAssetHandle mOldMesh = MeshAssetHandle::Null;
+};
 
-using EntityDeleteSkinnedMesh = EntityDefaultDeleteAction<SkinnedMesh>;
+/**
+ * @brief Delete entity mesh action
+ */
+class EntityDeleteMesh : public Action {
+public:
+  /**
+   * @brief Delete mesh from entity
+   *
+   * @param entity Entity mesh
+   */
+  EntityDeleteMesh(Entity entity);
+
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onExecute(WorkspaceState &state,
+                                 AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action executor
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @return Executor result
+   */
+  ActionExecutorResult onUndo(WorkspaceState &state,
+                              AssetRegistry &assetRegistry) override;
+
+  /**
+   * @brief Action predicate
+   *
+   * @param state Workspace state
+   * @param assetRegistry Asset registry
+   * @retval true Predicate is true
+   * @retval false Predicate is false
+   */
+  bool predicate(WorkspaceState &state, AssetRegistry &assetRegistry) override;
+
+private:
+  Entity mEntity;
+  MeshAssetHandle mOldMesh = MeshAssetHandle::Null;
+};
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/actions/SpawnEntityActions.cpp
+++ b/editor/src/liquidator/actions/SpawnEntityActions.cpp
@@ -46,8 +46,9 @@ static bool isPrefabValid(AssetRegistry &assetRegistry,
   const auto &prefab = prefabs.getAsset(handle).data;
 
   return !prefab.animators.empty() || !prefab.meshes.empty() ||
-         !prefab.skeletons.empty() || !prefab.skinnedMeshes.empty() ||
-         !prefab.transforms.empty();
+         !prefab.skeletons.empty() || !prefab.transforms.empty() ||
+         !prefab.directionalLights.empty() || !prefab.pointLights.empty() ||
+         !prefab.meshRenderers.empty() || !prefab.skinnedMeshRenderers.empty();
 }
 
 ActionExecutorResult

--- a/editor/src/liquidator/asset/gltf/GLTFImportData.h
+++ b/editor/src/liquidator/asset/gltf/GLTFImportData.h
@@ -63,26 +63,6 @@ struct AnimationData {
 };
 
 /**
- * @brief Mesh material data
- *
- * Used to store mapping between
- * mesh assets and materials that point
- * to each primitive of the mesh
- */
-struct MeshMaterialData {
-  /**
-   * Mesh material map
-   */
-  std::map<MeshAssetHandle, std::vector<MaterialAssetHandle>> meshMaterialMap;
-
-  /**
-   * Skinned mesh material map
-   */
-  std::map<MeshAssetHandle, std::vector<MaterialAssetHandle>>
-      skinnedMeshMaterialMap;
-};
-
-/**
  * @brief GLTF import data
  *
  * Stores all the information to perform the import
@@ -149,14 +129,10 @@ struct GLTFImportData {
   GLTFToAsset<MeshAssetHandle> meshes;
 
   /**
-   * Skinned mesh map
+   * Map of materials associated
+   * with meshes
    */
-  GLTFToAsset<MeshAssetHandle> skinnedMeshes;
-
-  /**
-   * Mesh material data
-   */
-  MeshMaterialData meshMaterialData;
+  std::map<MeshAssetHandle, std::vector<MaterialAssetHandle>> meshMaterials;
 
   /**
    * Directional light map

--- a/editor/src/liquidator/asset/gltf/MeshStep.cpp
+++ b/editor/src/liquidator/asset/gltf/MeshStep.cpp
@@ -473,37 +473,17 @@ void loadMeshes(GLTFImportData &importData) {
       return;
     }
 
-    if (isSkinnedMesh) {
-      mesh.type = AssetType::SkinnedMesh;
-      mesh.name = getGLTFAssetName(importData, assetName);
+    mesh.type = isSkinnedMesh ? AssetType::SkinnedMesh : AssetType::Mesh;
+    mesh.name = getGLTFAssetName(importData, assetName);
+    auto path =
+        assetCache.createMeshFromAsset(mesh, getUUID(importData, assetName));
+    auto handle = assetCache.loadMeshFromFile(path.getData());
+    importData.meshes.map.insert_or_assign(i, handle.getData());
 
-      auto path = assetCache.createSkinnedMeshFromAsset(
-          mesh, getUUID(importData, assetName));
-      auto handle = assetCache.loadSkinnedMeshFromFile(path.getData());
-
-      importData.skinnedMeshes.map.insert_or_assign(i, handle.getData());
-      importData.meshMaterialData.skinnedMeshMaterialMap.insert_or_assign(
-          handle.getData(), materials);
-      importData.outputUuids.insert_or_assign(assetName,
-                                              assetCache.getRegistry()
-                                                  .getSkinnedMeshes()
-                                                  .getAsset(handle.getData())
-                                                  .uuid);
-    } else {
-      mesh.name = getGLTFAssetName(importData, assetName);
-      mesh.type = AssetType::Mesh;
-
-      auto path =
-          assetCache.createMeshFromAsset(mesh, getUUID(importData, assetName));
-      auto handle = assetCache.loadMeshFromFile(path.getData());
-
-      importData.meshes.map.insert_or_assign(i, handle.getData());
-      importData.meshMaterialData.meshMaterialMap.insert_or_assign(
-          handle.getData(), materials);
-      importData.outputUuids.insert_or_assign(
-          assetName,
-          assetCache.getRegistry().getMeshes().getAsset(handle.getData()).uuid);
-    }
+    importData.meshMaterials.insert_or_assign(handle.getData(), materials);
+    importData.outputUuids.insert_or_assign(
+        assetName,
+        assetCache.getRegistry().getMeshes().getAsset(handle.getData()).uuid);
   }
 }
 

--- a/editor/src/liquidator/asset/gltf/PrefabStep.cpp
+++ b/editor/src/liquidator/asset/gltf/PrefabStep.cpp
@@ -49,9 +49,7 @@ void loadPrefabs(GLTFImportData &importData) {
 
     bool hasValidMesh =
         node.mesh >= 0 &&
-        (importData.skinnedMeshes.map.find(node.mesh) !=
-             importData.skinnedMeshes.map.end() ||
-         importData.meshes.map.find(node.mesh) != importData.meshes.map.end());
+        importData.meshes.map.find(node.mesh) != importData.meshes.map.end();
     bool hasValidLight = false;
 
     auto itExtLight = node.extensions.find("KHR_lights_punctual");
@@ -84,17 +82,13 @@ void loadPrefabs(GLTFImportData &importData) {
         {localEntityId, node.name.empty() ? "Untitled" : node.name});
 
     if (hasValidMesh) {
+      auto handle = importData.meshes.map.at(node.mesh);
+      const auto &asset =
+          importData.assetCache.getRegistry().getMeshes().getAsset(handle);
+      const auto &materials = importData.meshMaterials.at(handle);
+      prefab.data.meshes.push_back({localEntityId, handle});
+
       if (node.skin >= 0) {
-        auto handle = importData.skinnedMeshes.map.at(node.mesh);
-        const auto &asset =
-            importData.assetCache.getRegistry().getSkinnedMeshes().getAsset(
-                handle);
-
-        auto materials =
-            importData.meshMaterialData.skinnedMeshMaterialMap.at(handle);
-
-        prefab.data.skinnedMeshes.push_back({localEntityId, handle});
-
         SkinnedMeshRenderer renderer{materials};
         prefab.data.skinnedMeshRenderers.push_back({localEntityId, renderer});
 
@@ -106,16 +100,7 @@ void loadPrefabs(GLTFImportData &importData) {
         if (it != importData.animations.skinAnimatorMap.end()) {
           prefab.data.animators.push_back({localEntityId, it->second});
         }
-
       } else {
-        auto handle = importData.meshes.map.at(node.mesh);
-        const auto &asset =
-            importData.assetCache.getRegistry().getMeshes().getAsset(handle);
-
-        auto materials = importData.meshMaterialData.meshMaterialMap.at(handle);
-
-        prefab.data.meshes.push_back({localEntityId, handle});
-
         MeshRenderer renderer{materials};
         prefab.data.meshRenderers.push_back({localEntityId, renderer});
 

--- a/editor/src/liquidator/core/EditorRenderer.cpp
+++ b/editor/src/liquidator/core/EditorRenderer.cpp
@@ -501,7 +501,7 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
 
       const auto &world =
           entityDatabase.get<WorldTransform>(state.selectedEntity);
-      const auto &data = assetRegistry.getSkinnedMeshes().getAsset(handle).data;
+      const auto &data = assetRegistry.getMeshes().getAsset(handle).data;
 
       const auto &skeleton = entityDatabase.get<Skeleton>(state.selectedEntity)
                                  .jointFinalTransforms;

--- a/editor/src/liquidator/core/MousePickingGraph.cpp
+++ b/editor/src/liquidator/core/MousePickingGraph.cpp
@@ -345,8 +345,7 @@ void MousePickingGraph::createRenderGraph() {
 
       uint32_t instanceStart = 0;
       for (auto &[handle, meshData] : frameData.getSkinnedMeshGroups()) {
-        const auto &mesh =
-            mAssetRegistry.getSkinnedMeshes().getAsset(handle).data;
+        const auto &mesh = mAssetRegistry.getMeshes().getAsset(handle).data;
 
         uint32_t numInstances =
             static_cast<uint32_t>(meshData.transforms.size());

--- a/editor/src/liquidator/ui/AssetBrowser.cpp
+++ b/editor/src/liquidator/ui/AssetBrowser.cpp
@@ -467,12 +467,6 @@ void AssetBrowser::fetchPrefab(PrefabAssetHandle handle,
     addPrefabEntry(assetRegistry.getMeshes(), ref.value, meshCache);
   }
 
-  std::unordered_map<MeshAssetHandle, bool> skinnedMeshCache;
-  for (const auto &ref : prefab.data.skinnedMeshes) {
-    addPrefabEntry(assetRegistry.getSkinnedMeshes(), ref.value,
-                   skinnedMeshCache);
-  }
-
   for (const auto &renderer : prefab.data.meshRenderers) {
     for (auto material : renderer.value.materials) {
       addMaterialEntry(material);

--- a/editor/src/liquidator/ui/EntityPanel.cpp
+++ b/editor/src/liquidator/ui/EntityPanel.cpp
@@ -600,7 +600,7 @@ void EntityPanel::renderMesh(Scene &scene, AssetRegistry &assetRegistry,
       auto handle =
           scene.entityDatabase.get<SkinnedMesh>(mSelectedEntity).handle;
 
-      const auto &asset = assetRegistry.getSkinnedMeshes().getAsset(handle);
+      const auto &asset = assetRegistry.getMeshes().getAsset(handle);
 
       if (auto table = widgets::Table("TableSkinnedMesh", 2)) {
         table.row("Name", asset.name);
@@ -610,7 +610,7 @@ void EntityPanel::renderMesh(Scene &scene, AssetRegistry &assetRegistry,
     }
 
     if (shouldDelete("SkinnedMesh")) {
-      actionExecutor.execute<EntityDeleteSkinnedMesh>(mSelectedEntity);
+      actionExecutor.execute<EntityDeleteMesh>(mSelectedEntity);
     }
   }
 }
@@ -1368,29 +1368,13 @@ void EntityPanel::handleDragAndDrop(Scene &scene, AssetRegistry &assetRegistry,
     if (auto *payload = ImGui::AcceptDragDropPayload(
             getAssetTypeString(AssetType::Mesh).c_str())) {
       auto asset = *static_cast<MeshAssetHandle *>(payload->Data);
-
-      if (scene.entityDatabase.has<Mesh>(mSelectedEntity)) {
-        actionExecutor.execute<EntitySetMesh>(
-            mSelectedEntity, scene.entityDatabase.get<Mesh>(mSelectedEntity),
-            Mesh{asset});
-      } else {
-        actionExecutor.execute<EntityCreateMesh>(mSelectedEntity, Mesh{asset});
-      }
+      actionExecutor.execute<EntitySetMesh>(mSelectedEntity, asset);
     }
 
     if (auto *payload = ImGui::AcceptDragDropPayload(
             getAssetTypeString(AssetType::SkinnedMesh).c_str())) {
       auto asset = *static_cast<MeshAssetHandle *>(payload->Data);
-
-      if (scene.entityDatabase.has<SkinnedMesh>(mSelectedEntity)) {
-        actionExecutor.execute<EntitySetSkinnedMesh>(
-            mSelectedEntity,
-            scene.entityDatabase.get<SkinnedMesh>(mSelectedEntity),
-            SkinnedMesh{asset});
-      } else {
-        actionExecutor.execute<EntityCreateSkinnedMesh>(mSelectedEntity,
-                                                        SkinnedMesh{asset});
-      }
+      actionExecutor.execute<EntitySetMesh>(mSelectedEntity, asset);
     }
 
     if (auto *payload = ImGui::AcceptDragDropPayload(

--- a/editor/tests/liquidator-tests/actions/EntityMeshActions.test.cpp
+++ b/editor/tests/liquidator-tests/actions/EntityMeshActions.test.cpp
@@ -5,34 +5,290 @@
 #include "ActionTestBase.h"
 #include "DefaultEntityTests.h"
 
-using EntityCreateMeshActionTest = ActionTestBase;
-InitDefaultCreateComponentTests(EntityCreateMeshActionTest, EntityCreateMesh,
-                                Mesh);
-InitActionsTestSuite(EntityActionsTest, EntityCreateMeshActionTest);
+class EntityMeshActionTestBase : public ActionTestBase {
+public:
+  liquid::MeshAssetHandle createMesh() {
+    liquid::AssetData<liquid::MeshAsset> asset{};
+    asset.type = liquid::AssetType::Mesh;
+    return assetRegistry.getMeshes().addAsset(asset);
+  }
 
-using EntityUpdateMeshActionTest = ActionTestBase;
-InitDefaultUpdateComponentTests(EntityUpdateMeshActionTest, EntitySetMesh, Mesh,
-                                handle, liquid::MeshAssetHandle{25});
-InitActionsTestSuite(EntityActionsTest, EntityUpdateMeshActionTest);
+  liquid::MeshAssetHandle createSkinnedMesh() {
+    liquid::AssetData<liquid::MeshAsset> asset{};
+    asset.type = liquid::AssetType::SkinnedMesh;
+    return assetRegistry.getMeshes().addAsset(asset);
+  }
+};
 
-using EntityDeleteMeshActionTest = ActionTestBase;
-InitDefaultDeleteComponentTests(EntityDeleteMeshActionTest, EntityDeleteMesh,
-                                Mesh);
-InitActionsTestSuite(EntityActionsTest, EntityDeleteMeshActionTest);
+using EntitySetMeshTest = EntityMeshActionTestBase;
 
-// Skinned mesh
-using EntityCreateSkinnedMeshActionTest = ActionTestBase;
-InitDefaultCreateComponentTests(EntityCreateSkinnedMeshActionTest,
-                                EntityCreateSkinnedMesh, SkinnedMesh);
-InitActionsTestSuite(EntityActionsTest, EntityCreateSkinnedMeshActionTest);
+TEST_P(EntitySetMeshTest, ExecutorSetsMeshComponentIfMeshTypeIsMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto mesh = createMesh();
 
-using EntityUpdateSkinnedMeshActionTest = ActionTestBase;
-InitDefaultUpdateComponentTests(EntityUpdateSkinnedMeshActionTest,
-                                EntitySetSkinnedMesh, SkinnedMesh, handle,
-                                liquid::MeshAssetHandle{25});
-InitActionsTestSuite(EntityActionsTest, EntityUpdateSkinnedMeshActionTest);
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  auto res = action.onExecute(state, assetRegistry);
 
-using EntityDeleteSkinnedMeshActionTest = ActionTestBase;
-InitDefaultDeleteComponentTests(EntityDeleteSkinnedMeshActionTest,
-                                EntityDeleteSkinnedMesh, SkinnedMesh);
-InitActionsTestSuite(EntityActionsTest, EntityDeleteSkinnedMeshActionTest);
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_EQ(activeScene().entityDatabase.get<liquid::Mesh>(entity).handle,
+            mesh);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntitySetMeshTest,
+       ExecutorSetsSkinnedMeshComponentIfMeshTypeIsSkinnedMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto mesh = createSkinnedMesh();
+
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  auto res = action.onExecute(state, assetRegistry);
+
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_EQ(
+      activeScene().entityDatabase.get<liquid::SkinnedMesh>(entity).handle,
+      mesh);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntitySetMeshTest,
+       ExecutorReplacesSkinnedMeshWithMeshIfNewAssetTypeIsMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createSkinnedMesh();
+  auto mesh = createMesh();
+  activeScene().entityDatabase.set<liquid::SkinnedMesh>(entity, {oldMesh});
+
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  auto res = action.onExecute(state, assetRegistry);
+
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_EQ(activeScene().entityDatabase.get<liquid::Mesh>(entity).handle,
+            mesh);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntitySetMeshTest,
+       ExecutorReplacesMeshWithSkinnedMeshIfNewAssetTypeIsSkinnedMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createMesh();
+  auto mesh = createSkinnedMesh();
+  activeScene().entityDatabase.set<liquid::Mesh>(entity, {oldMesh});
+
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  auto res = action.onExecute(state, assetRegistry);
+
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_EQ(
+      activeScene().entityDatabase.get<liquid::SkinnedMesh>(entity).handle,
+      mesh);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntitySetMeshTest, UndoSetsPreviousMeshHandleIfSameComponent) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createMesh();
+  auto mesh = createMesh();
+
+  activeScene().entityDatabase.set<liquid::Mesh>(entity, {oldMesh});
+
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  action.onExecute(state, assetRegistry);
+  auto res = action.onUndo(state, assetRegistry);
+
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_EQ(activeScene().entityDatabase.get<liquid::Mesh>(entity).handle,
+            oldMesh);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+}
+
+TEST_P(EntitySetMeshTest, UndoSetsPreviousSkinnedMeshHandleIfSameComponent) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createSkinnedMesh();
+  auto mesh = createSkinnedMesh();
+
+  activeScene().entityDatabase.set<liquid::SkinnedMesh>(entity, {oldMesh});
+
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  action.onExecute(state, assetRegistry);
+  auto res = action.onUndo(state, assetRegistry);
+
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_EQ(
+      activeScene().entityDatabase.get<liquid::SkinnedMesh>(entity).handle,
+      oldMesh);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+}
+
+TEST_P(EntitySetMeshTest, UndoReplacesNewMeshWithOldSkinnedMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createSkinnedMesh();
+  auto mesh = createMesh();
+
+  activeScene().entityDatabase.set<liquid::SkinnedMesh>(entity, {oldMesh});
+
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  action.onExecute(state, assetRegistry);
+  auto res = action.onUndo(state, assetRegistry);
+
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_EQ(
+      activeScene().entityDatabase.get<liquid::SkinnedMesh>(entity).handle,
+      oldMesh);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+}
+
+TEST_P(EntitySetMeshTest, UndoReplacesNewSkinnedMeshWithOldMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createMesh();
+  auto mesh = createSkinnedMesh();
+
+  activeScene().entityDatabase.set<liquid::Mesh>(entity, {oldMesh});
+
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  action.onExecute(state, assetRegistry);
+  auto res = action.onUndo(state, assetRegistry);
+
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_EQ(activeScene().entityDatabase.get<liquid::Mesh>(entity).handle,
+            oldMesh);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+}
+
+TEST_P(EntitySetMeshTest, UndoDeletesMeshComponentIfNoPreviousComponent) {
+  auto entity = activeScene().entityDatabase.create();
+  auto mesh = createMesh();
+
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  action.onExecute(state, assetRegistry);
+  auto res = action.onUndo(state, assetRegistry);
+
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+}
+
+TEST_P(EntitySetMeshTest,
+       UndoDeletesSkinnedMeshComponentIfNoPreviousComponent) {
+  auto entity = activeScene().entityDatabase.create();
+  auto mesh = createSkinnedMesh();
+
+  liquid::editor::EntitySetMesh action(entity, mesh);
+  action.onExecute(state, assetRegistry);
+  auto res = action.onUndo(state, assetRegistry);
+
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+}
+
+TEST_P(EntitySetMeshTest, PredicateReturnsTrueIfMeshExists) {
+  auto entity = activeScene().entityDatabase.create();
+  auto mesh = createSkinnedMesh();
+
+  EXPECT_TRUE(liquid::editor::EntitySetMesh(entity, mesh)
+                  .predicate(state, assetRegistry));
+}
+
+TEST_P(EntitySetMeshTest, PredicateReturnsFalseIfMeshDoesNotExist) {
+  auto entity = activeScene().entityDatabase.create();
+
+  EXPECT_FALSE(
+      liquid::editor::EntitySetMesh(entity, liquid::MeshAssetHandle{25})
+          .predicate(state, assetRegistry));
+}
+
+InitActionsTestSuite(EntityActionsTest, EntitySetMeshTest);
+
+using EntityDeleteMeshTest = EntityMeshActionTestBase;
+
+TEST_P(EntityDeleteMeshTest, ExecutorDeletesMeshIfCurrentComponentIsMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createMesh();
+
+  activeScene().entityDatabase.set<liquid::Mesh>(entity, {oldMesh});
+  liquid::editor::EntityDeleteMesh action(entity);
+  auto res = action.onExecute(state, assetRegistry);
+
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntityDeleteMeshTest,
+       ExecutorDeletesSkinnedMeshIfCurrentComponentIsSkinnedMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createSkinnedMesh();
+
+  activeScene().entityDatabase.set<liquid::SkinnedMesh>(entity, {oldMesh});
+  liquid::editor::EntityDeleteMesh action(entity);
+  auto res = action.onExecute(state, assetRegistry);
+
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_FALSE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(res.addToHistory);
+}
+
+TEST_P(EntityDeleteMeshTest, UndoRecreatesMeshIfDeletedComponentWasMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createMesh();
+
+  activeScene().entityDatabase.set<liquid::Mesh>(entity, {oldMesh});
+  liquid::editor::EntityDeleteMesh action(entity);
+  action.onExecute(state, assetRegistry);
+  auto res = action.onUndo(state, assetRegistry);
+
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_EQ(activeScene().entityDatabase.get<liquid::Mesh>(entity).handle,
+            oldMesh);
+}
+
+TEST_P(EntityDeleteMeshTest,
+       UndoRecreatesSkinnedMeshIfDeletedComponentWasSkinnedMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto oldMesh = createSkinnedMesh();
+
+  activeScene().entityDatabase.set<liquid::SkinnedMesh>(entity, {oldMesh});
+  liquid::editor::EntityDeleteMesh action(entity);
+  action.onExecute(state, assetRegistry);
+  auto res = action.onUndo(state, assetRegistry);
+
+  EXPECT_TRUE(activeScene().entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_EQ(
+      activeScene().entityDatabase.get<liquid::SkinnedMesh>(entity).handle,
+      oldMesh);
+}
+
+TEST_P(EntityDeleteMeshTest, PredicateReturnsTrueIfEntityHasMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto mesh = createMesh();
+  activeScene().entityDatabase.set<liquid::Mesh>(entity, {mesh});
+
+  EXPECT_TRUE(
+      liquid::editor::EntityDeleteMesh(entity).predicate(state, assetRegistry));
+}
+
+TEST_P(EntityDeleteMeshTest, PredicateReturnsTrueIfEntityHasSkinnedMesh) {
+  auto entity = activeScene().entityDatabase.create();
+  auto mesh = createSkinnedMesh();
+  activeScene().entityDatabase.set<liquid::SkinnedMesh>(entity, {mesh});
+
+  EXPECT_TRUE(
+      liquid::editor::EntityDeleteMesh(entity).predicate(state, assetRegistry));
+}
+
+TEST_P(EntityDeleteMeshTest,
+       PredicateReturnsFalseIfEntityHasNoMeshOrSkinnedMesh) {
+  auto entity = activeScene().entityDatabase.create();
+
+  EXPECT_FALSE(
+      liquid::editor::EntityDeleteMesh(entity).predicate(state, assetRegistry));
+}
+
+InitActionsTestSuite(EntityActionsTest, EntityDeleteMeshTest);

--- a/engine/src/liquid/asset/AssetCache.cpp
+++ b/engine/src/liquid/asset/AssetCache.cpp
@@ -33,7 +33,7 @@ Result<AssetFileHeader> AssetCache::checkAssetFile(InputBinaryStream &file,
         "Opened file is not a liquid asset: " + filePath.string());
   }
 
-  if (header.type != assetType) {
+  if (assetType != AssetType::None && header.type != assetType) {
     return Result<AssetFileHeader>::Error("Opened file is not a liquid " +
                                           getAssetTypeString(assetType) +
                                           " asset: " + filePath.string());
@@ -178,7 +178,7 @@ Result<bool> AssetCache::loadAsset(const Path &path, bool updateExisting) {
   }
 
   if (header.type == AssetType::SkinnedMesh) {
-    auto res = loadSkinnedMeshDataFromInputStream(stream, path, header);
+    auto res = loadMeshDataFromInputStream(stream, path, header);
 
     if (res.hasError()) {
       return Result<bool>::Error(res.getError());

--- a/engine/src/liquid/asset/AssetCache.h
+++ b/engine/src/liquid/asset/AssetCache.h
@@ -117,27 +117,6 @@ public:
   Result<MeshAssetHandle> loadMeshFromFile(const Path &filePath);
 
   /**
-   * @brief Create skinned mesh from asset
-   *
-   * Create engine specific skinned mesh asset
-   * from mesh data
-   *
-   * @param asset Mesh asset
-   * @param uuid Asset uuid
-   * @return Path to new mesh asset
-   */
-  Result<Path> createSkinnedMeshFromAsset(const AssetData<MeshAsset> &asset,
-                                          const String &uuid);
-
-  /**
-   * @brief Load skinned mesh from file
-   *
-   * @param filePath Path to asset
-   * @return Skinned mesh asset handle
-   */
-  Result<MeshAssetHandle> loadSkinnedMeshFromFile(const Path &filePath);
-
-  /**
    * @brief Create skeleton from asset
    *
    * Create engine specific skeleton asset
@@ -419,19 +398,6 @@ private:
                               const AssetFileHeader &header);
 
   /**
-   * @brief Load skinned mesh from input stream
-   *
-   * @param stream Input stream
-   * @param filePath Path to asset
-   * @param header Asset file header
-   * @return Skinned mesh asset handle
-   */
-  Result<MeshAssetHandle>
-  loadSkinnedMeshDataFromInputStream(InputBinaryStream &stream,
-                                     const Path &filePath,
-                                     const AssetFileHeader &header);
-
-  /**
    * @brief Load skeleton from input stream
    *
    * @param stream Input stream
@@ -513,14 +479,6 @@ private:
    * @return Existing or newly loaded mesh
    */
   Result<MeshAssetHandle> getOrLoadMeshFromUuid(const String &uuid);
-
-  /**
-   * @brief Get or load skinned mesh from uuid
-   *
-   * @param uuid Asset uuid
-   * @return Existing or newly loaded skinned mesh
-   */
-  Result<MeshAssetHandle> getOrLoadSkinnedMeshFromUuid(const String &uuid);
 
   /**
    * @brief Get or load skeleton from uuid

--- a/engine/src/liquid/asset/AssetCacheMesh.cpp
+++ b/engine/src/liquid/asset/AssetCacheMesh.cpp
@@ -21,7 +21,7 @@ Result<Path> AssetCache::createMeshFromAsset(const AssetData<MeshAsset> &asset,
   }
 
   AssetFileHeader header{};
-  header.type = AssetType::Mesh;
+  header.type = asset.type;
   header.magic = AssetFileHeader::MagicConstant;
   header.name = asset.name;
   file.write(header);
@@ -37,6 +37,11 @@ Result<Path> AssetCache::createMeshFromAsset(const AssetData<MeshAsset> &asset,
     file.write(geometry.tangents);
     file.write(geometry.texCoords0);
     file.write(geometry.texCoords1);
+
+    if (asset.type == AssetType::SkinnedMesh) {
+      file.write(geometry.joints);
+      file.write(geometry.weights);
+    }
 
     auto numIndices = static_cast<uint32_t>(geometry.indices.size());
     file.write(numIndices);
@@ -55,7 +60,7 @@ AssetCache::loadMeshDataFromInputStream(InputBinaryStream &stream,
   AssetData<MeshAsset> mesh{};
   mesh.name = header.name;
   mesh.path = filePath;
-  mesh.type = AssetType::Mesh;
+  mesh.type = header.type;
   mesh.uuid = filePath.stem().string();
 
   uint32_t numGeometries = 0;
@@ -85,6 +90,13 @@ AssetCache::loadMeshDataFromInputStream(InputBinaryStream &stream,
     stream.read(g.texCoords0);
     stream.read(g.texCoords1);
 
+    if (mesh.type == AssetType::SkinnedMesh) {
+      g.joints.resize(numVertices);
+      g.weights.resize(numVertices);
+      stream.read(g.joints);
+      stream.read(g.weights);
+    }
+
     uint32_t numIndices = 0;
     stream.read(numIndices);
 
@@ -103,123 +115,18 @@ AssetCache::loadMeshDataFromInputStream(InputBinaryStream &stream,
 Result<MeshAssetHandle> AssetCache::loadMeshFromFile(const Path &filePath) {
   InputBinaryStream stream(filePath);
 
-  const auto &header = checkAssetFile(stream, filePath, AssetType::Mesh);
+  const auto &header = checkAssetFile(stream, filePath, AssetType::None);
   if (header.hasError()) {
     return Result<MeshAssetHandle>::Error(header.getError());
+  }
+
+  if (header.getData().type != AssetType::Mesh &&
+      header.getData().type != AssetType::SkinnedMesh) {
+    return Result<MeshAssetHandle>::Error(
+        "Opened file is not a liquid asset: " + filePath.string());
   }
 
   return loadMeshDataFromInputStream(stream, filePath, header.getData());
-}
-
-Result<Path>
-AssetCache::createSkinnedMeshFromAsset(const AssetData<MeshAsset> &asset,
-                                       const String &uuid) {
-  auto assetPath = createAssetPath(uuid);
-
-  OutputBinaryStream file(assetPath);
-
-  if (!file.good()) {
-    return Result<Path>::Error("File cannot be opened for writing: " +
-                               assetPath.string());
-  }
-
-  AssetFileHeader header{};
-  header.magic = AssetFileHeader::MagicConstant;
-  header.name = asset.name;
-  header.type = AssetType::SkinnedMesh;
-  file.write(header);
-
-  auto numGeometries = static_cast<uint32_t>(asset.data.geometries.size());
-  file.write(numGeometries);
-
-  for (auto &geometry : asset.data.geometries) {
-    auto numVertices = static_cast<uint32_t>(geometry.positions.size());
-    file.write(numVertices);
-    file.write(geometry.positions);
-    file.write(geometry.normals);
-    file.write(geometry.tangents);
-    file.write(geometry.texCoords0);
-    file.write(geometry.texCoords1);
-    file.write(geometry.joints);
-    file.write(geometry.weights);
-
-    auto numIndices = static_cast<uint32_t>(geometry.indices.size());
-    file.write(numIndices);
-    file.write(geometry.indices);
-  }
-
-  return Result<Path>::Ok(assetPath);
-}
-
-Result<MeshAssetHandle>
-AssetCache::loadSkinnedMeshDataFromInputStream(InputBinaryStream &stream,
-                                               const Path &filePath,
-                                               const AssetFileHeader &header) {
-  std::vector<String> warnings;
-
-  AssetData<MeshAsset> mesh{};
-  mesh.name = header.name;
-  mesh.path = filePath;
-  mesh.type = AssetType::SkinnedMesh;
-  mesh.uuid = filePath.stem().string();
-
-  uint32_t numGeometries = 0;
-  stream.read(numGeometries);
-
-  mesh.data.geometries.resize(numGeometries);
-
-  for (uint32_t i = 0; i < numGeometries; ++i) {
-    uint32_t numVertices = 0;
-    stream.read(numVertices);
-    if (numVertices == 0) {
-      return Result<MeshAssetHandle>::Error(
-          "Skinned mesh geometry has no vertices");
-    }
-
-    auto &g = mesh.data.geometries.at(i);
-
-    g.positions.resize(numVertices);
-    g.normals.resize(numVertices);
-    g.tangents.resize(numVertices);
-    g.texCoords0.resize(numVertices);
-    g.texCoords1.resize(numVertices);
-    g.joints.resize(numVertices);
-    g.weights.resize(numVertices);
-
-    stream.read(g.positions);
-    stream.read(g.normals);
-    stream.read(g.tangents);
-    stream.read(g.texCoords0);
-    stream.read(g.texCoords1);
-    stream.read(g.joints);
-    stream.read(g.weights);
-
-    uint32_t numIndices = 0;
-    stream.read(numIndices);
-
-    if (numIndices == 0) {
-      return Result<MeshAssetHandle>::Error(
-          "Skinned mesh geometry has no indices");
-    }
-
-    mesh.data.geometries.at(i).indices.resize(numIndices);
-    stream.read(mesh.data.geometries.at(i).indices);
-  }
-
-  return Result<MeshAssetHandle>::Ok(
-      mRegistry.getSkinnedMeshes().addAsset(mesh), warnings);
-}
-
-Result<MeshAssetHandle>
-AssetCache::loadSkinnedMeshFromFile(const Path &filePath) {
-  InputBinaryStream stream(filePath);
-
-  const auto &header = checkAssetFile(stream, filePath, AssetType::SkinnedMesh);
-  if (header.hasError()) {
-    return Result<MeshAssetHandle>::Error(header.getError());
-  }
-
-  return loadSkinnedMeshDataFromInputStream(stream, filePath, header.getData());
 }
 
 Result<MeshAssetHandle> AssetCache::getOrLoadMeshFromUuid(const String &uuid) {
@@ -233,20 +140,6 @@ Result<MeshAssetHandle> AssetCache::getOrLoadMeshFromUuid(const String &uuid) {
   }
 
   return loadMeshFromFile(getPathFromUuid(uuid));
-}
-
-Result<MeshAssetHandle>
-AssetCache::getOrLoadSkinnedMeshFromUuid(const String &uuid) {
-  if (uuid.empty()) {
-    return Result<MeshAssetHandle>::Ok(MeshAssetHandle::Null);
-  }
-
-  auto handle = mRegistry.getSkinnedMeshes().findHandleByUuid(uuid);
-  if (handle != MeshAssetHandle::Null) {
-    return Result<MeshAssetHandle>::Ok(handle);
-  }
-
-  return loadSkinnedMeshFromFile(getPathFromUuid(uuid));
 }
 
 } // namespace liquid

--- a/engine/src/liquid/asset/AssetRegistry.cpp
+++ b/engine/src/liquid/asset/AssetRegistry.cpp
@@ -156,54 +156,17 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
     CreateBuffer(texCoords0, glm::vec2);
     CreateBuffer(texCoords1, glm::vec2);
 
+    if (mesh.type == AssetType::SkinnedMesh) {
+      CreateBuffer(joints, glm::uvec4);
+      CreateBuffer(weights, glm::vec4);
+    }
+
     {
       rhi::BufferDescription description;
       description.usage = rhi::BufferUsage::Index;
       description.size = ibSize;
       description.data = nullptr;
       description.debugName = mesh.name + " indices";
-
-      auto buffer = renderStorage.createBuffer(description);
-
-      auto *data = static_cast<uint32_t *>(buffer.map());
-      size_t offset = 0;
-      for (auto &g : mesh.data.geometries) {
-        memcpy(data + offset, g.indices.data(),
-               g.indices.size() * sizeof(uint32_t));
-        offset += g.indices.size();
-      }
-
-      buffer.unmap();
-
-      mesh.data.indexBuffer = buffer.getHandle();
-    }
-  }
-
-  // Synchronize skinned meshes
-  for (auto &[_, mesh] : mSkinnedMeshes.getAssets()) {
-    if (!mesh.data.vertexBuffers.empty()) {
-      continue;
-    }
-
-    size_t ibSize = 0;
-    for (auto &g : mesh.data.geometries) {
-      ibSize += g.indices.size() * sizeof(uint32_t);
-    }
-
-    CreateBuffer(positions, glm::vec3);
-    CreateBuffer(normals, glm::vec3);
-    CreateBuffer(tangents, glm::vec4);
-    CreateBuffer(texCoords0, glm::vec2);
-    CreateBuffer(texCoords1, glm::vec2);
-    CreateBuffer(joints, glm::uvec4);
-    CreateBuffer(weights, glm::vec4);
-
-    {
-      rhi::BufferDescription description;
-      description.usage = rhi::BufferUsage::Index;
-      description.size = ibSize;
-      description.data = nullptr;
-      description.debugName = mesh.name + " index";
 
       auto buffer = renderStorage.createBuffer(description);
 
@@ -246,12 +209,6 @@ AssetRegistry::getAssetByUuid(const String &uuid) {
   for (auto &[handle, asset] : mMeshes.getAssets()) {
     if (asset.uuid == uuid) {
       return {AssetType::Mesh, static_cast<uint32_t>(handle)};
-    }
-  }
-
-  for (auto &[handle, asset] : mSkinnedMeshes.getAssets()) {
-    if (asset.uuid == uuid) {
-      return {AssetType::SkinnedMesh, static_cast<uint32_t>(handle)};
     }
   }
 

--- a/engine/src/liquid/asset/AssetRegistry.h
+++ b/engine/src/liquid/asset/AssetRegistry.h
@@ -32,7 +32,6 @@ class AssetRegistry {
   using FontMap = AssetMap<FontAssetHandle, FontAsset>;
   using MaterialMap = AssetMap<MaterialAssetHandle, MaterialAsset>;
   using MeshMap = AssetMap<MeshAssetHandle, MeshAsset>;
-  using SkinnedMeshMap = AssetMap<MeshAssetHandle, MeshAsset>;
   using SkeletonMap = AssetMap<SkeletonAssetHandle, SkeletonAsset>;
   using AnimationMap = AssetMap<AnimationAssetHandle, AnimationAsset>;
   using AnimatorMap = AssetMap<AnimatorAssetHandle, AnimatorAsset>;
@@ -116,13 +115,6 @@ public:
   inline MeshMap &getMeshes() { return mMeshes; }
 
   /**
-   * @brief Get skinned meshes
-   *
-   * @return Skinned mesh asset map
-   */
-  inline SkinnedMeshMap &getSkinnedMeshes() { return mSkinnedMeshes; }
-
-  /**
    * @brief Get skeletons
    *
    * @return Skeleton asset map
@@ -185,7 +177,6 @@ private:
   FontMap mFonts;
   MaterialMap mMaterials;
   MeshMap mMeshes;
-  SkinnedMeshMap mSkinnedMeshes;
   SkeletonMap mSkeletons;
   AnimationMap mAnimations;
   AnimatorMap mAnimators;

--- a/engine/src/liquid/asset/AssetRevision.h
+++ b/engine/src/liquid/asset/AssetRevision.h
@@ -12,7 +12,7 @@ enum class AssetRevision : uint32_t {
   Skeleton = 230911,
   Animation = 230911,
   Audio = 230911,
-  Prefab = 230915,
+  Prefab = 230817,
   LuaScript = 230911,
   Font = 230911,
   Environment = 230911,

--- a/engine/src/liquid/asset/PrefabAsset.h
+++ b/engine/src/liquid/asset/PrefabAsset.h
@@ -69,11 +69,6 @@ struct PrefabAsset {
   std::vector<PrefabComponent<MeshAssetHandle>> meshes;
 
   /**
-   * List of skinned meshes
-   */
-  std::vector<PrefabComponent<MeshAssetHandle>> skinnedMeshes;
-
-  /**
    * List of skeletons
    */
   std::vector<PrefabComponent<SkeletonAssetHandle>> skeletons;

--- a/engine/src/liquid/entity/EntitySpawner.cpp
+++ b/engine/src/liquid/entity/EntitySpawner.cpp
@@ -75,17 +75,18 @@ std::vector<Entity> EntitySpawner::spawnPrefab(PrefabAssetHandle handle,
 
   for (const auto &pMesh : asset.meshes) {
     auto entity = getOrCreateEntity(pMesh.entity);
-    mEntityDatabase.set<Mesh>(entity, {pMesh.value});
+
+    auto type = mAssetRegistry.getMeshes().getAsset(pMesh.value).type;
+    if (type == AssetType::Mesh) {
+      mEntityDatabase.set<Mesh>(entity, {pMesh.value});
+    } else if (type == AssetType::SkinnedMesh) {
+      mEntityDatabase.set<SkinnedMesh>(entity, {pMesh.value});
+    }
   }
 
   for (const auto &pRenderer : asset.meshRenderers) {
     auto entity = getOrCreateEntity(pRenderer.entity);
     mEntityDatabase.set(entity, pRenderer.value);
-  }
-
-  for (const auto &pSkinnedMesh : asset.skinnedMeshes) {
-    auto entity = getOrCreateEntity(pSkinnedMesh.entity);
-    mEntityDatabase.set<SkinnedMesh>(entity, {pSkinnedMesh.value});
   }
 
   for (const auto &pRenderer : asset.skinnedMeshRenderers) {

--- a/engine/src/liquid/entity/EntitySpawnerScriptingInterface.cpp
+++ b/engine/src/liquid/entity/EntitySpawnerScriptingInterface.cpp
@@ -18,8 +18,9 @@ namespace liquid {
  */
 static bool isPrefabEmpty(const PrefabAsset &prefab) {
   return prefab.animators.empty() && prefab.meshes.empty() &&
-         prefab.skeletons.empty() && prefab.skinnedMeshes.empty() &&
-         prefab.transforms.empty();
+         prefab.skeletons.empty() && prefab.directionalLights.empty() &&
+         prefab.pointLights.empty() && prefab.meshRenderers.empty() &&
+         prefab.skinnedMeshRenderers.empty() && prefab.transforms.empty();
 }
 
 int EntitySpawnerScriptingInterface::LuaInterface::spawnEmpty(void *state) {

--- a/engine/src/liquid/renderer/SceneRenderer.cpp
+++ b/engine/src/liquid/renderer/SceneRenderer.cpp
@@ -783,7 +783,7 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
   for (auto [entity, skeleton, world, mesh, renderer] :
        entityDatabase.view<Skeleton, WorldTransform, SkinnedMesh,
                            SkinnedMeshRenderer>()) {
-    const auto &asset = mAssetRegistry.getSkinnedMeshes().getAsset(mesh.handle);
+    const auto &asset = mAssetRegistry.getMeshes().getAsset(mesh.handle);
 
     std::vector<rhi::DeviceAddress> materials;
     for (auto material : renderer.materials) {
@@ -899,7 +899,7 @@ void SceneRenderer::renderSkinned(rhi::RenderCommandList &commandList,
   uint32_t instanceStart = 0;
 
   for (auto &[handle, meshData] : frameData.getSkinnedMeshGroups()) {
-    const auto &mesh = mAssetRegistry.getSkinnedMeshes().getAsset(handle).data;
+    const auto &mesh = mAssetRegistry.getMeshes().getAsset(handle).data;
     uint32_t numInstances = static_cast<uint32_t>(meshData.transforms.size());
 
     commandList.bindVertexBuffers(mesh.vertexBuffers, mesh.vertexBufferOffsets);
@@ -964,7 +964,7 @@ void SceneRenderer::renderShadowsSkinnedMesh(
 
   uint32_t instanceStart = 0;
   for (auto &[handle, meshData] : frameData.getSkinnedMeshGroups()) {
-    const auto &mesh = mAssetRegistry.getSkinnedMeshes().getAsset(handle).data;
+    const auto &mesh = mAssetRegistry.getMeshes().getAsset(handle).data;
     uint32_t numInstances = static_cast<uint32_t>(meshData.transforms.size());
 
     commandList.bindVertexBuffers(

--- a/engine/src/liquid/scene/private/EntitySerializer.cpp
+++ b/engine/src/liquid/scene/private/EntitySerializer.cpp
@@ -161,6 +161,13 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
 
       components["mesh"] = uuid;
     }
+  } else if (mEntityDatabase.has<SkinnedMesh>(entity)) {
+    auto handle = mEntityDatabase.get<SkinnedMesh>(entity).handle;
+    if (mAssetRegistry.getMeshes().hasAsset(handle)) {
+      auto uuid = mAssetRegistry.getMeshes().getAsset(handle).uuid;
+
+      components["mesh"] = uuid;
+    }
   }
 
   if (mEntityDatabase.has<MeshRenderer>(entity)) {
@@ -174,15 +181,6 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
         auto uuid = mAssetRegistry.getMaterials().getAsset(material).uuid;
         components["meshRenderer"]["materials"].push_back(uuid);
       }
-    }
-  }
-
-  if (mEntityDatabase.has<SkinnedMesh>(entity)) {
-    auto handle = mEntityDatabase.get<SkinnedMesh>(entity).handle;
-    if (mAssetRegistry.getSkinnedMeshes().hasAsset(handle)) {
-      auto uuid = mAssetRegistry.getSkinnedMeshes().getAsset(handle).uuid;
-
-      components["skinnedMesh"] = uuid;
     }
   }
 

--- a/engine/src/liquid/scene/private/SceneLoader.cpp
+++ b/engine/src/liquid/scene/private/SceneLoader.cpp
@@ -140,7 +140,13 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
     auto handle = mAssetRegistry.getMeshes().findHandleByUuid(uuid);
 
     if (handle != MeshAssetHandle::Null) {
-      mEntityDatabase.set<Mesh>(entity, {handle});
+      auto type = mAssetRegistry.getMeshes().getAsset(handle).type;
+
+      if (type == AssetType::Mesh) {
+        mEntityDatabase.set<Mesh>(entity, {handle});
+      } else if (type == AssetType::SkinnedMesh) {
+        mEntityDatabase.set<SkinnedMesh>(entity, {handle});
+      }
     }
   }
 
@@ -162,15 +168,6 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
     }
 
     mEntityDatabase.set(entity, renderer);
-  }
-
-  if (node["components"]["skinnedMesh"]) {
-    auto uuid = node["components"]["skinnedMesh"].as<String>("");
-    auto handle = mAssetRegistry.getSkinnedMeshes().findHandleByUuid(uuid);
-
-    if (handle != MeshAssetHandle::Null) {
-      mEntityDatabase.set<SkinnedMesh>(entity, {handle});
-    }
   }
 
   if (node["components"]["skinnedMeshRenderer"] &&

--- a/engine/tests/liquid-tests/asset/AssetCacheMesh.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheMesh.test.cpp
@@ -14,6 +14,7 @@ public:
   liquid::AssetData<liquid::MeshAsset> createRandomizedMeshAsset() {
     liquid::AssetData<liquid::MeshAsset> asset;
     asset.name = "test-mesh0";
+    asset.type = liquid::AssetType::Mesh;
 
     {
       std::random_device device;
@@ -48,6 +49,7 @@ public:
   liquid::AssetData<liquid::MeshAsset> createRandomizedSkinnedMeshAsset() {
     liquid::AssetData<liquid::MeshAsset> asset;
     asset.name = "test-mesh0";
+    asset.type = liquid::AssetType::SkinnedMesh;
 
     std::random_device device;
     std::mt19937 mt(device());
@@ -187,7 +189,9 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadMeshIfItHasNoIndices) {
 TEST_F(AssetCacheMeshTest, LoadsMeshFromFile) {
   auto asset = createRandomizedMeshAsset();
   auto filePath = cache.createMeshFromAsset(asset, "").getData();
-  auto handle = cache.loadMeshFromFile(filePath).getData();
+  auto handleRes = cache.loadMeshFromFile(filePath);
+
+  auto handle = handleRes.getData();
   EXPECT_NE(handle, liquid::MeshAssetHandle::Null);
   auto &mesh = cache.getRegistry().getMeshes().getAsset(handle);
   EXPECT_EQ(mesh.name, asset.name);
@@ -219,7 +223,7 @@ TEST_F(AssetCacheMeshTest, LoadsMeshFromFile) {
 TEST_F(AssetCacheMeshTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
   auto asset = createRandomizedSkinnedMeshAsset();
 
-  auto filePath = cache.createSkinnedMeshFromAsset(asset, "");
+  auto filePath = cache.createMeshFromAsset(asset, "");
 
   liquid::InputBinaryStream file(filePath.getData());
   EXPECT_TRUE(file.good());
@@ -316,8 +320,8 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadSkinnedMeshIfItHasNoVertices) {
     geometry.positions.clear();
   }
 
-  auto filePath = cache.createSkinnedMeshFromAsset(asset, "").getData();
-  auto handle = cache.loadSkinnedMeshFromFile(filePath);
+  auto filePath = cache.createMeshFromAsset(asset, "").getData();
+  auto handle = cache.loadMeshFromFile(filePath);
   EXPECT_TRUE(handle.hasError());
 }
 
@@ -327,19 +331,18 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadSkinnedMeshIfItHasNoIndices) {
     geometry.indices.clear();
   }
 
-  auto filePath = cache.createSkinnedMeshFromAsset(asset, "").getData();
-  auto handle = cache.loadSkinnedMeshFromFile(filePath);
+  auto filePath = cache.createMeshFromAsset(asset, "").getData();
+  auto handle = cache.loadMeshFromFile(filePath);
   EXPECT_TRUE(handle.hasError());
 }
 
 TEST_F(AssetCacheMeshTest, LoadsSkinnedMeshFromFile) {
   auto asset = createRandomizedSkinnedMeshAsset();
 
-  auto filePath = cache.createSkinnedMeshFromAsset(asset, "");
-  auto handle = cache.loadSkinnedMeshFromFile(filePath.getData());
+  auto filePath = cache.createMeshFromAsset(asset, "");
+  auto handle = cache.loadMeshFromFile(filePath.getData());
   EXPECT_NE(handle.getData(), liquid::MeshAssetHandle::Null);
-  auto &mesh =
-      cache.getRegistry().getSkinnedMeshes().getAsset(handle.getData());
+  auto &mesh = cache.getRegistry().getMeshes().getAsset(handle.getData());
   EXPECT_EQ(mesh.name, asset.name);
 
   for (size_t g = 0; g < asset.data.geometries.size(); ++g) {

--- a/engine/tests/liquid-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/liquid-tests/entity/EntitySpawner.test.cpp
@@ -57,9 +57,12 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
 
   // Create two meshes
   for (uint32_t i = 0; i < 2; ++i) {
+    liquid::AssetData<liquid::MeshAsset> meshAsset{};
+    meshAsset.type = liquid::AssetType::Mesh;
+
     liquid::PrefabComponent<liquid::MeshAssetHandle> mesh{};
     mesh.entity = i;
-    mesh.value = liquid::MeshAssetHandle{i};
+    mesh.value = assetRegistry.getMeshes().addAsset(meshAsset);
     asset.data.meshes.push_back(mesh);
   }
 
@@ -92,10 +95,13 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
 
   // Create three skinned meshes
   for (uint32_t i = 2; i < 5; ++i) {
+    liquid::AssetData<liquid::MeshAsset> meshAsset{};
+    meshAsset.type = liquid::AssetType::SkinnedMesh;
+
     liquid::PrefabComponent<liquid::MeshAssetHandle> mesh{};
     mesh.entity = i;
-    mesh.value = liquid::MeshAssetHandle{i};
-    asset.data.skinnedMeshes.push_back(mesh);
+    mesh.value = assetRegistry.getMeshes().addAsset(meshAsset);
+    asset.data.meshes.push_back(mesh);
   }
 
   // create skeletons for skinned meshes
@@ -203,7 +209,15 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
     auto entity = res.at(i);
 
     const auto &mesh = db.get<liquid::Mesh>(entity);
-    EXPECT_EQ(mesh.handle, static_cast<liquid::MeshAssetHandle>(i));
+    EXPECT_EQ(mesh.handle, asset.data.meshes.at(i).value);
+  }
+
+  // Test skinned meshes
+  for (uint32_t i = 2; i < 5; ++i) {
+    auto entity = res.at(i);
+
+    const auto &mesh = db.get<liquid::SkinnedMesh>(entity);
+    EXPECT_EQ(mesh.handle, asset.data.meshes.at(i).value);
   }
 
   // Test mesh renderers
@@ -215,14 +229,6 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
       EXPECT_EQ(renderer.materials.at(mi),
                 static_cast<liquid::MaterialAssetHandle>(mi + 1));
     }
-  }
-
-  // Test skinned meshes
-  for (uint32_t i = 2; i < 5; ++i) {
-    auto entity = res.at(i);
-
-    const auto &mesh = db.get<liquid::SkinnedMesh>(entity);
-    EXPECT_EQ(mesh.handle, static_cast<liquid::MeshAssetHandle>(i));
   }
 
   // Test skinned mesh renderer
@@ -311,8 +317,12 @@ TEST_F(
     transform.value.parent = -1;
     asset.data.transforms.push_back(transform);
 
+    liquid::AssetData<liquid::MeshAsset> meshData{};
+    meshData.type = liquid::AssetType::SkinnedMesh;
+
     liquid::PrefabComponent<liquid::MeshAssetHandle> mesh{};
     mesh.entity = 1;
+    mesh.value = assetRegistry.getMeshes().addAsset(meshData);
     asset.data.meshes.push_back(mesh);
   }
   auto prefab = assetRegistry.getPrefabs().addAsset(asset);

--- a/engine/tests/liquid-tests/scene/private/EntitySerializer.test.cpp
+++ b/engine/tests/liquid-tests/scene/private/EntitySerializer.test.cpp
@@ -261,14 +261,14 @@ TEST_F(EntitySerializerTest,
        CreatesSkinnedMeshFieldIfSkinnedMeshAssetIsRegistry) {
   liquid::AssetData<liquid::MeshAsset> mesh{};
   mesh.uuid = "skinnedMesh.mesh";
-  auto handle = assetRegistry.getSkinnedMeshes().addAsset(mesh);
+  auto handle = assetRegistry.getMeshes().addAsset(mesh);
 
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::SkinnedMesh>(entity, {handle});
 
   auto node = entitySerializer.createComponentsNode(entity);
-  EXPECT_TRUE(node["skinnedMesh"]);
-  EXPECT_EQ(node["skinnedMesh"].as<liquid::String>(""), "skinnedMesh.mesh");
+  EXPECT_TRUE(node["mesh"]);
+  EXPECT_EQ(node["mesh"].as<liquid::String>(""), "skinnedMesh.mesh");
 }
 
 // Skinned mesh renderer

--- a/engine/tests/liquid-tests/scene/private/SceneLoader.test.cpp
+++ b/engine/tests/liquid-tests/scene/private/SceneLoader.test.cpp
@@ -256,6 +256,7 @@ TEST_F(SceneLoaderMeshTest,
        DoesNotCreateMeshComponentIfNoMeshHandleInRegistry) {
   liquid::AssetData<liquid::MeshAsset> data{};
   data.uuid = "hello";
+  data.type = liquid::AssetType::Mesh;
   auto handle = assetRegistry.getMeshes().addAsset(data);
 
   auto [node, entity] = createNode();
@@ -265,8 +266,9 @@ TEST_F(SceneLoaderMeshTest,
   EXPECT_FALSE(entityDatabase.has<liquid::Mesh>(entity));
 }
 
-TEST_F(SceneLoaderMeshTest, CreatesMeshComponentWithFileDataIfValidField) {
+TEST_F(SceneLoaderMeshTest, CreatesMeshComponentIfValidAssetTypeIsMesh) {
   liquid::AssetData<liquid::MeshAsset> data{};
+  data.type = liquid::AssetType::Mesh;
   data.uuid = "hello";
   auto handle = assetRegistry.getMeshes().addAsset(data);
 
@@ -275,56 +277,23 @@ TEST_F(SceneLoaderMeshTest, CreatesMeshComponentWithFileDataIfValidField) {
   sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
   ASSERT_TRUE(entityDatabase.has<liquid::Mesh>(entity));
+  EXPECT_FALSE(entityDatabase.has<liquid::SkinnedMesh>(entity));
   EXPECT_EQ(entityDatabase.get<liquid::Mesh>(entity).handle, handle);
 }
 
 TEST_F(SceneLoaderMeshTest,
-       DoesNotCreateSkinnedMeshComponentIfMeshFieldIsNotDefined) {
-  auto [node, entity] = createNode();
-  sceneLoader.loadComponents(node, entity, entityIdCache).getData();
-
-  EXPECT_FALSE(entityDatabase.has<liquid::SkinnedMesh>(entity));
-}
-
-TEST_F(SceneLoaderMeshTest,
-       DoesNotCreateSkinnedMeshComponentIfMeshFieldIsInvalid) {
-  std::vector<YAML::Node> invalidNodes{
-      YAML::Node(YAML::NodeType::Undefined), YAML::Node(YAML::NodeType::Null),
-      YAML::Node(YAML::NodeType::Map), YAML::Node(YAML::NodeType::Sequence),
-      YAML::Node(YAML::NodeType::Scalar)};
-
-  for (const auto &invalidNode : invalidNodes) {
-    auto [node, entity] = createNode();
-    node["skinnedMesh"] = invalidNode;
-    sceneLoader.loadComponents(node, entity, entityIdCache).getData();
-    EXPECT_FALSE(entityDatabase.has<liquid::SkinnedMesh>(entity));
-  }
-}
-
-TEST_F(SceneLoaderMeshTest,
-       DoesNotCreateSkinnedMeshComponentIfNoSkinnedMeshHandleInRegistry) {
+       CreatesSkinnedMeshComponentIfValidAssetTypeIsSkinnedMesh) {
   liquid::AssetData<liquid::MeshAsset> data{};
+  data.type = liquid::AssetType::SkinnedMesh;
   data.uuid = "hello";
-  auto handle = assetRegistry.getSkinnedMeshes().addAsset(data);
+  auto handle = assetRegistry.getMeshes().addAsset(data);
 
   auto [node, entity] = createNode();
-  node["components"]["skinnedMesh"] = "bye";
-  sceneLoader.loadComponents(node, entity, entityIdCache).getData();
-
-  EXPECT_FALSE(entityDatabase.has<liquid::SkinnedMesh>(entity));
-}
-
-TEST_F(SceneLoaderMeshTest,
-       CreatesSkinnedMeshComponentWithFileDataIfValidField) {
-  liquid::AssetData<liquid::MeshAsset> data{};
-  data.uuid = "hello";
-  auto handle = assetRegistry.getSkinnedMeshes().addAsset(data);
-
-  auto [node, entity] = createNode();
-  node["components"]["skinnedMesh"] = data.uuid;
+  node["components"]["mesh"] = data.uuid;
   sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
   ASSERT_TRUE(entityDatabase.has<liquid::SkinnedMesh>(entity));
+  EXPECT_FALSE(entityDatabase.has<liquid::Mesh>(entity));
   EXPECT_EQ(entityDatabase.get<liquid::SkinnedMesh>(entity).handle, handle);
 }
 

--- a/engine/tests/liquid-tests/test-utils/AssetCacheTestBase.cpp
+++ b/engine/tests/liquid-tests/test-utils/AssetCacheTestBase.cpp
@@ -9,7 +9,8 @@ const liquid::Path AssetCacheTestBase::CachePath =
 AssetCacheTestBase::AssetCacheTestBase() : cache(CachePath) {}
 
 void AssetCacheTestBase::SetUp() {
+  std::filesystem::remove_all(CachePath);
   std::filesystem::create_directory(CachePath);
 }
 
-void AssetCacheTestBase::TearDown() { std::filesystem::remove_all(CachePath); }
+void AssetCacheTestBase::TearDown() {}


### PR DESCRIPTION
- Store both mesh and skinned mesh assets in the same map
- Add new mesh actions that manage skinned and static meshes automatically
- Use one loader for mesh and skinned meshes
- Merge skinned meshes and meshes from prefab
- Merge skinnedMesh and mesh in scene files
- Refactor GLTF Importer