### PR TITLE
Decouple samplers from textures

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -70,7 +70,8 @@ layout(set = 0, binding = 1) uniform SceneData { ... } uSceneData;
 layout(set = 0, binding = 2) uniform samplerCube uIblMaps[2];
 
 layout(set = 1, binding = 0) uniform MaterialData { ... } uMaterialData;
-layout(set = 1, binding = 1) uniform sampler2D uTextures[8];
+layout(set = 1, binding = 1) uniform texture2D uTextures[8];
+layout(set = 1, binding = 2) uniform sampler2D uSamplers[8];
 ```
 
 > **Note:**
@@ -145,7 +146,7 @@ layout(set = 1, binding = 0) uniform CameraData {
     mat4 viewProj;
 } uCameraData;
 
-layout(set = 1, binding = 1) uniform sampler2D uTextures;
+layout(set = 1, binding = 1) uniform texture2D uTextures;
 ```
 
 > **Note:**

--- a/editor/assets/shaders/equirectangular-to-cubemap.comp
+++ b/editor/assets/shaders/equirectangular-to-cubemap.comp
@@ -3,8 +3,9 @@
 
 #include "../../../engine/assets/shaders/generate-ibl.glsl"
 
-layout(set = 0, binding = 0) uniform sampler2D uInputTexture;
-layout(set = 0, binding = 1,
+layout(set = 0, binding = 0) uniform texture2D uInputTexture;
+layout(set = 0, binding = 1) uniform sampler uInputSampler;
+layout(set = 0, binding = 2,
        rgba16f) writeonly uniform imageCube uOutputTexture;
 
 layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
@@ -19,7 +20,7 @@ void main() {
   uv *= invAtan;
   uv += 0.5;
 
-  vec4 color = texture(uInputTexture, uv);
+  vec4 color = texture(sampler2D(uInputTexture, uInputSampler), uv);
 
   imageStore(uOutputTexture, globalId, color);
 }

--- a/editor/assets/shaders/generate-irradiance-map.comp
+++ b/editor/assets/shaders/generate-irradiance-map.comp
@@ -3,8 +3,9 @@
 
 #include "../../../engine/assets/shaders/generate-ibl.glsl"
 
-layout(set = 0, binding = 0) uniform samplerCube uInputTexture;
-layout(set = 0, binding = 1,
+layout(set = 0, binding = 0) uniform textureCube uInputTexture;
+layout(set = 0, binding = 1) uniform sampler uInputSampler;
+layout(set = 0, binding = 2,
        rgba16f) writeonly uniform imageCube uOutputTexture;
 
 layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
@@ -26,7 +27,9 @@ void main() {
 
     float lod = 0.5 * log2(6.0 * width * width / (float(NumSamples) * pdf));
 
-    irradiance += textureLod(uInputTexture, H, lod).rgb * NdotH;
+    irradiance +=
+        textureLod(samplerCube(uInputTexture, uInputSampler), H, lod).rgb *
+        NdotH;
   }
 
   irradiance /= float(NumSamples);

--- a/editor/assets/shaders/generate-specular-map.comp
+++ b/editor/assets/shaders/generate-specular-map.comp
@@ -4,8 +4,9 @@
 
 #include "../../../engine/assets/shaders/generate-ibl.glsl"
 
-layout(set = 0, binding = 0) uniform samplerCube uInputTexture;
-layout(set = 0, binding = 1,
+layout(set = 0, binding = 0) uniform textureCube uInputTexture;
+layout(set = 0, binding = 1) uniform sampler uInputSampler;
+layout(set = 0, binding = 2,
        rgba16f) writeonly uniform imageCube uOutputTexture;
 
 layout(push_constant) uniform PushConstants { vec4 data; }
@@ -29,8 +30,9 @@ void main() {
   }
 
   if (roughness == 0.0) {
-    imageStore(uOutputTexture, ivec3(gl_GlobalInvocationID),
-               textureLod(uInputTexture, normal, 0));
+    imageStore(
+        uOutputTexture, ivec3(gl_GlobalInvocationID),
+        textureLod(samplerCube(uInputTexture, uInputSampler), normal, 0));
     return;
   }
 
@@ -54,7 +56,10 @@ void main() {
 
       float mipLevel =
           0.5 * log2(6.0 * mipWidth * mipWidth / (float(NumSamples) * pdf));
-      specular += textureLod(uInputTexture, L, mipLevel).rgb * NdotL;
+      specular +=
+          textureLod(samplerCube(uInputTexture, uInputSampler), L, mipLevel)
+              .rgb *
+          NdotL;
       totalWeight += NdotL;
     }
   }

--- a/editor/assets/shaders/object-icons.frag
+++ b/editor/assets/shaders/object-icons.frag
@@ -6,8 +6,9 @@ layout(location = 0) out vec4 outColor;
 
 #include "bindless-editor.glsl"
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
   Empty gizmoTransforms;
@@ -28,5 +29,7 @@ layout(push_constant) uniform IconParams { uvec4 icon; }
 uIconParams;
 
 void main() {
-  outColor = texture(uGlobalTextures[uIconParams.icon.x], inTexCoord);
+  outColor = texture(sampler2D(uGlobalTextures[uIconParams.icon.x],
+                               uGlobalSamplers[uIconParams.icon.y]),
+                     inTexCoord);
 }

--- a/editor/assets/shaders/outline-text.frag
+++ b/editor/assets/shaders/outline-text.frag
@@ -5,8 +5,9 @@ layout(location = 0) in vec2 inTexCoord;
 
 layout(location = 0) out vec4 outColor;
 
-layout(set = 1, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 1, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 1, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 1, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 1, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 /**
  * @brief Push constant outlines
@@ -24,13 +25,18 @@ float median(vec3 msd) {
 
 float screenPxRange() {
   vec2 unitRange =
-      vec2(2.0) / vec2(textureSize(uGlobalTextures[uOutline.index.z], 0));
+      vec2(2.0) / vec2(textureSize(sampler2D(uGlobalTextures[uOutline.index.z],
+                                             uGlobalSamplers[uOutline.index.w]),
+                                   0));
   vec2 screenTexSize = vec2(1.0) / fwidth(inTexCoord);
   return max(0.5 * dot(unitRange, screenTexSize), 1.0);
 }
 
 void main() {
-  vec3 msd = texture(uGlobalTextures[uOutline.index.z], inTexCoord).rgb;
+  vec3 msd = texture(sampler2D(uGlobalTextures[uOutline.index.z],
+                               uGlobalSamplers[uOutline.index.w]),
+                     inTexCoord)
+                 .rgb;
   float sd = median(msd);
   float screenPxDistance = screenPxRange() * (sd - 0.5);
   float opacity = clamp(screenPxDistance + 0.5, 0.0, 1.0);

--- a/editor/assets/shaders/outline-text.vert
+++ b/editor/assets/shaders/outline-text.vert
@@ -17,8 +17,9 @@ layout(set = 0, binding = 0) uniform DrawParameters {
 }
 uDrawParams;
 
-layout(set = 1, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 1, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 1, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 1, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 1, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 #define getOutlineTransform(index) uDrawParams.outlineTransforms.items[index]
 

--- a/editor/src/liquidator/core/EditorRenderer.h
+++ b/editor/src/liquidator/core/EditorRenderer.h
@@ -96,6 +96,8 @@ private:
 
   RenderStorage &mRenderStorage;
   std::array<EditorRendererFrameData, rhi::RenderDevice::NumFrames> mFrameData;
+
+  rhi::SamplerHandle mTextOutlineSampler = rhi::SamplerHandle::Null;
 };
 
 } // namespace liquid::editor

--- a/engine/assets/shaders/bindless/base.glsl
+++ b/engine/assets/shaders/bindless/base.glsl
@@ -4,7 +4,8 @@
 #define Bindless 1
 #define BindlessDescriptorSet 0
 #define BindlessTexturesBinding 0
-#define BindlessImagesBinding 1
+#define BindlessSamplersBinding 1
+#define BindlessImagesBinding 2
 
 #define Buffer(alignment)                                                      \
   layout(buffer_reference, std430, buffer_reference_align = alignment) buffer

--- a/engine/assets/shaders/bloom-downsample.comp
+++ b/engine/assets/shaders/bloom-downsample.comp
@@ -4,13 +4,17 @@
 
 layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform DrawParameters { uvec4 textures; };
 
 vec3 sampleSource(float x, float y) {
-  return texture(uGlobalTextures[textures.x], vec2(x, y)).rgb;
+  return texture(sampler2D(uGlobalTextures[textures.x],
+                           uGlobalSamplers[textures.z]),
+                 vec2(x, y))
+      .rgb;
 }
 
 vec3 pow3(vec3 v, float p) {
@@ -52,7 +56,7 @@ void main() {
 
   vec3 color = vec3(0.0);
 
-  if (textures.z == 0) {
+  if (textures.w == 0) {
     vec3 c0 = (a + b + d + e) * (0.125 / 4.0);
     vec3 c1 = (b + c + e + f) * (0.125 / 4.0);
     vec3 c2 = (d + e + g + h) * (0.125 / 4.0);

--- a/engine/assets/shaders/bloom-upsample.comp
+++ b/engine/assets/shaders/bloom-upsample.comp
@@ -4,13 +4,17 @@
 
 layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform DrawParameters { uvec4 textures; };
 
 vec3 sampleSource(float x, float y) {
-  return texture(uGlobalTextures[textures.x], vec2(x, y)).rgb;
+  return texture(sampler2D(uGlobalTextures[textures.x],
+                           uGlobalSamplers[textures.z]),
+                 vec2(x, y))
+      .rgb;
 }
 
 void main() {

--- a/engine/assets/shaders/extract-bright-colors.comp
+++ b/engine/assets/shaders/extract-bright-colors.comp
@@ -5,20 +5,24 @@
 
 layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform DrawParameters { uvec4 textures; };
 
 const float BrightnessTreshold = 1.0;
 
 void main() {
-  uvec2 size = textureSize(uGlobalTextures[textures.y], 0);
+  uvec2 size = textureSize(
+      sampler2D(uGlobalTextures[textures.y], uGlobalSamplers[textures.z]), 0);
 
   vec2 texCoord = vec2(float(gl_GlobalInvocationID.x) / float(size.x),
                        float(gl_GlobalInvocationID.y) / float(size.y));
 
-  vec4 color = texture(uGlobalTextures[textures.x], texCoord);
+  vec4 color = texture(
+      sampler2D(uGlobalTextures[textures.x], uGlobalSamplers[textures.z]),
+      texCoord);
 
   float brightness = 0.2126 * color.x + 0.7152 * color.y + 0.0722 * color.z;
 

--- a/engine/assets/shaders/fullscreen-quad.frag
+++ b/engine/assets/shaders/fullscreen-quad.frag
@@ -4,6 +4,7 @@ layout(location = 0) in vec2 inTexCoord;
 
 layout(location = 0) out vec4 outColor;
 
-layout(set = 0, binding = 0) uniform sampler2D uTexture;
+layout(set = 0, binding = 0) uniform texture2D uTexture;
+layout(set = 0, binding = 1) uniform sampler uSampler;
 
-void main() { outColor = texture(uTexture, inTexCoord); }
+void main() { outColor = texture(sampler2D(uTexture, uSampler), inTexCoord); }

--- a/engine/assets/shaders/geometry-skinned.vert
+++ b/engine/assets/shaders/geometry-skinned.vert
@@ -18,8 +18,9 @@ layout(location = 6) out uint outMaterialIndex;
 #include "bindless/camera.glsl"
 #include "bindless/material.glsl"
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
   MaterialsArray materials;

--- a/engine/assets/shaders/geometry.vert
+++ b/engine/assets/shaders/geometry.vert
@@ -16,8 +16,9 @@ layout(location = 6) out uint outMaterialIndex;
 #include "bindless/camera.glsl"
 #include "bindless/material.glsl"
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
   MaterialsArray materials;

--- a/engine/assets/shaders/hdr.frag
+++ b/engine/assets/shaders/hdr.frag
@@ -8,13 +8,15 @@ layout(location = 0) in vec2 inTexCoord;
 
 layout(location = 0) out vec4 outColor;
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform DrawParameters {
+  Camera camera;
   uint sceneTexture;
   uint bloomTexture;
-  Camera camera;
+  uint defaultSampler;
 }
 uDrawParams;
 
@@ -51,9 +53,14 @@ const float BloomContribution = 0.2;
 
 void main() {
   vec4 hdrColor =
-      texture(uGlobalTextures[uDrawParams.sceneTexture], inTexCoord);
+      texture(sampler2D(uGlobalTextures[uDrawParams.sceneTexture],
+                        uGlobalSamplers[uDrawParams.defaultSampler]),
+              inTexCoord);
   vec3 bloomColor =
-      texture(uGlobalTextures[uDrawParams.bloomTexture], inTexCoord).rgb;
+      texture(sampler2D(uGlobalTextures[uDrawParams.bloomTexture],
+                        uGlobalSamplers[uDrawParams.defaultSampler]),
+              inTexCoord)
+          .rgb;
 
   float ev100 = getCamera().exposure.x;
 

--- a/engine/assets/shaders/imgui.frag
+++ b/engine/assets/shaders/imgui.frag
@@ -8,12 +8,15 @@ layout(location = 1) in vec2 inTexCoord;
 
 layout(location = 0) out vec4 outColor;
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
-layout(push_constant) uniform TextureData { layout(offset = 64) uint index; }
+layout(push_constant) uniform TextureData { layout(offset = 64) uvec4 index; }
 uTextureData;
 
 void main() {
-  outColor = inColor * texture(uGlobalTextures[uTextureData.index], inTexCoord);
+  outColor = inColor * texture(sampler2D(uGlobalTextures[uTextureData.index.x],
+                                         uGlobalSamplers[uTextureData.index.y]),
+                               inTexCoord);
 }

--- a/engine/assets/shaders/skybox.frag
+++ b/engine/assets/shaders/skybox.frag
@@ -7,8 +7,9 @@ layout(location = 0) out vec4 outColor;
 
 #include "bindless/base.glsl"
 
-layout(set = 0, binding = 0) uniform samplerCube uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform textureCube uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 /**
  * @brief Skybox
@@ -30,6 +31,7 @@ Buffer(16) Skybox {
 layout(set = 1, binding = 0) uniform DrawParams {
   Empty camera;
   Skybox skybox;
+  uint defaultSampler;
 }
 uDrawParams;
 
@@ -38,7 +40,10 @@ uDrawParams;
 void main() {
   if (getSkybox().data.x > 0) {
     vec3 color =
-        textureLod(uGlobalTextures[getSkybox().data.x], inTexCoord, 0).xyz;
+        textureLod(samplerCube(uGlobalTextures[getSkybox().data.x],
+                               uGlobalSamplers[uDrawParams.defaultSampler]),
+                   inTexCoord, 0)
+            .xyz;
 
     outColor = vec4(color, 1.0);
   } else {

--- a/engine/assets/shaders/skybox.vert
+++ b/engine/assets/shaders/skybox.vert
@@ -11,6 +11,7 @@ layout(location = 0) out vec3 outTexCoord;
 layout(set = 1, binding = 0) uniform DrawParameters {
   Camera camera;
   Empty skybox;
+  uint defaultSampler;
 }
 uDrawParams;
 

--- a/engine/assets/shaders/sprite.frag
+++ b/engine/assets/shaders/sprite.frag
@@ -12,15 +12,20 @@ layout(location = 1) in flat uint inTextureIndex;
 
 layout(location = 0) out vec4 outColor;
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
   Empty camera;
   Empty transforms;
   SpritesArray sprites;
-  Empty pad0;
+  uint defaultSampler;
 }
 uDrawParams;
 
-void main() { outColor = texture(uGlobalTextures[inTextureIndex], inTexCoord); }
+void main() {
+  outColor = texture(sampler2D(uGlobalTextures[inTextureIndex],
+                               uGlobalSamplers[uDrawParams.defaultSampler]),
+                     inTexCoord);
+}

--- a/engine/assets/shaders/sprite.vert
+++ b/engine/assets/shaders/sprite.vert
@@ -10,14 +10,15 @@ Buffer(16) SpritesArray { uint items[]; };
 layout(location = 0) out vec2 outTexCoord;
 layout(location = 1) out flat uint outTextureIndex;
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(set = 1, binding = 0) uniform DrawParameters {
   Camera camera;
   TransformsArray transforms;
   SpritesArray sprites;
-  Empty pad0;
+  uint pad0;
 }
 uDrawParams;
 

--- a/engine/assets/shaders/text.frag
+++ b/engine/assets/shaders/text.frag
@@ -7,8 +7,9 @@ layout(location = 0) out vec4 outColor;
 
 #include "bindless/base.glsl"
 
-layout(set = 0, binding = 0) uniform sampler2D uGlobalTextures[];
-layout(set = 0, binding = 1) writeonly uniform image2D uGlobalImages[];
+layout(set = 0, binding = 0) uniform texture2D uGlobalTextures[];
+layout(set = 0, binding = 1) uniform sampler uGlobalSamplers[];
+layout(set = 0, binding = 2) writeonly uniform image2D uGlobalImages[];
 
 layout(push_constant) uniform PushConstants { uvec4 text; }
 uTextParams;
@@ -19,13 +20,19 @@ float median(vec3 msd) {
 
 float screenPxRange() {
   vec2 unitRange =
-      vec2(2.0) / vec2(textureSize(uGlobalTextures[uTextParams.text.x], 0));
+      vec2(2.0) /
+      vec2(textureSize(sampler2D(uGlobalTextures[uTextParams.text.x],
+                                 uGlobalSamplers[uTextParams.text.y]),
+                       0));
   vec2 screenTexSize = vec2(1.0) / fwidth(texCoord);
   return max(0.5 * dot(unitRange, screenTexSize), 1.0);
 }
 
 void main() {
-  vec3 msd = texture(uGlobalTextures[uTextParams.text.x], texCoord).rgb;
+  vec3 msd = texture(sampler2D(uGlobalTextures[uTextParams.text.x],
+                               uGlobalSamplers[uTextParams.text.y]),
+                     texCoord)
+                 .rgb;
   float sd = median(msd);
   float screenPxDistance = screenPxRange() * (sd - 0.5);
   float opacity = clamp(screenPxDistance + 0.5, 0.0, 1.0);

--- a/engine/assets/shaders/text.vert
+++ b/engine/assets/shaders/text.vert
@@ -25,7 +25,7 @@ void main() {
 
   uint boundIndex = gl_VertexIndex % QUAD_VERTICES;
   uint glyphIndex =
-      uTextParams.text.y + uint(floor(gl_VertexIndex / QUAD_VERTICES));
+      uTextParams.text.z + uint(floor(gl_VertexIndex / QUAD_VERTICES));
 
   GlyphItem glyph = getGlyph(glyphIndex);
 

--- a/engine/rhi/core/include/liquid/rhi/Descriptor.h
+++ b/engine/rhi/core/include/liquid/rhi/Descriptor.h
@@ -37,6 +37,17 @@ public:
                     DescriptorType type, uint32_t start = 0);
 
   /**
+   * @brief Bind sampler descriptors
+   *
+   * @param binding Binding number
+   * @param samplers Samplers
+   * @param start Starting index
+   * @return Current object
+   */
+  Descriptor &write(uint32_t binding, std::span<SamplerHandle> samplers,
+                    uint32_t start = 0);
+
+  /**
    * @brief Bind buffer descriptors
    *
    * @param binding Binding number

--- a/engine/rhi/core/include/liquid/rhi/DescriptorType.h
+++ b/engine/rhi/core/include/liquid/rhi/DescriptorType.h
@@ -6,8 +6,9 @@ enum class DescriptorType {
   UniformBuffer,
   UniformBufferDynamic,
   StorageBuffer,
-  CombinedImageSampler,
+  SampledImage,
   StorageImage,
+  Sampler,
   None
 };
 

--- a/engine/rhi/core/include/liquid/rhi/NativeDescriptor.h
+++ b/engine/rhi/core/include/liquid/rhi/NativeDescriptor.h
@@ -42,6 +42,16 @@ public:
                      DescriptorType type, uint32_t start) = 0;
 
   /**
+   * @brief Bind sampler descriptors
+   *
+   * @param binding Binding number
+   * @param samplers Samplers
+   * @param start Starting index
+   */
+  virtual void write(uint32_t binding, std::span<SamplerHandle> samplers,
+                     uint32_t start) = 0;
+
+  /**
    * @brief Bind buffer descriptors
    *
    * @param binding Binding number

--- a/engine/rhi/core/include/liquid/rhi/RenderDevice.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderDevice.h
@@ -15,6 +15,7 @@
 #include "RenderPassDescription.h"
 #include "FramebufferDescription.h"
 #include "PipelineDescription.h"
+#include "SamplerDescription.h"
 
 namespace liquid::rhi {
 
@@ -184,6 +185,22 @@ public:
    */
   virtual void createTextureView(const TextureViewDescription &description,
                                  TextureHandle handle) = 0;
+
+  /**
+   * @brief Create sampler
+   *
+   * @param description Sampler description
+   * @param handle Sampler handle
+   */
+  virtual void createSampler(const SamplerDescription &description,
+                             SamplerHandle handle) = 0;
+
+  /**
+   * @brief Destroy sampler
+   *
+   * @param handle Sampler handle
+   */
+  virtual void destroySampler(SamplerHandle handle) = 0;
 
   /**
    * @brief Create render pass

--- a/engine/rhi/core/include/liquid/rhi/RenderHandle.h
+++ b/engine/rhi/core/include/liquid/rhi/RenderHandle.h
@@ -8,6 +8,8 @@ enum class BufferHandle : uint32_t { Null = 0 };
 
 enum class TextureHandle : uint32_t { Null = 0 };
 
+enum class SamplerHandle : uint32_t { Null = 0 };
+
 enum class RenderPassHandle : uint32_t { Null = 0 };
 
 enum class FramebufferHandle : uint32_t { Null = 0 };
@@ -36,10 +38,11 @@ inline constexpr bool IsAnySame = (std::is_same_v<T, Rest> || ...);
  * @retval false Handle is not valid
  */
 template <class THandle> constexpr inline bool isHandleValid(THandle handle) {
-  static_assert(IsAnySame<THandle, ShaderHandle, BufferHandle, TextureHandle,
-                          RenderPassHandle, FramebufferHandle, PipelineHandle,
-                          DescriptorLayoutHandle, DescriptorHandle>,
-                "Type must be a render handle");
+  static_assert(
+      IsAnySame<THandle, ShaderHandle, BufferHandle, TextureHandle,
+                SamplerHandle, RenderPassHandle, FramebufferHandle,
+                PipelineHandle, DescriptorLayoutHandle, DescriptorHandle>,
+      "Type must be a render handle");
   return handle != THandle::Null;
 }
 
@@ -52,10 +55,11 @@ template <class THandle> constexpr inline bool isHandleValid(THandle handle) {
  */
 template <class THandle>
 constexpr inline uint32_t castHandleToUint(THandle handle) {
-  static_assert(IsAnySame<THandle, ShaderHandle, BufferHandle, TextureHandle,
-                          RenderPassHandle, FramebufferHandle, PipelineHandle,
-                          DescriptorLayoutHandle, DescriptorHandle>,
-                "Type must be a render handle");
+  static_assert(
+      IsAnySame<THandle, ShaderHandle, BufferHandle, TextureHandle,
+                SamplerHandle, RenderPassHandle, FramebufferHandle,
+                PipelineHandle, DescriptorLayoutHandle, DescriptorHandle>,
+      "Type must be a render handle");
 
   return static_cast<uint32_t>(handle);
 }

--- a/engine/rhi/core/include/liquid/rhi/SamplerDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/SamplerDescription.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "Filter.h"
+#include "WrapMode.h"
+
+namespace liquid::rhi {
+
+/**
+ * @brief Sampler description
+ */
+struct SamplerDescription {
+  /**
+   * Minification filter
+   */
+  Filter minFilter = Filter::Linear;
+
+  /**
+   * Magnification filter
+   */
+  Filter magFilter = Filter::Linear;
+
+  /**
+   * Wrap mode for U coordinates
+   */
+  WrapMode wrapModeU = WrapMode::Repeat;
+
+  /**
+   * Wrapping mode for V coordinates
+   */
+  WrapMode wrapModeV = WrapMode::Repeat;
+
+  /**
+   * Wrapping mode for W coordinates
+   */
+  WrapMode wrapModeW = WrapMode::Repeat;
+
+  /**
+   * Clamp Lod to minimum value
+   */
+  float minLod = 0.0f;
+
+  /**
+   * Maximum clamped Lod value
+   *
+   * If value is 0.0, maximum value
+   * clamping is disabled
+   */
+  float maxLod = 0.0f;
+
+  /**
+   * Debug name
+   */
+  String debugName;
+};
+
+} // namespace liquid::rhi

--- a/engine/rhi/core/include/liquid/rhi/TextureDescription.h
+++ b/engine/rhi/core/include/liquid/rhi/TextureDescription.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "liquid/rhi/Format.h"
+#include "liquid/rhi/RenderHandle.h"
 
 namespace liquid::rhi {
 

--- a/engine/rhi/core/include/liquid/rhi/WrapMode.h
+++ b/engine/rhi/core/include/liquid/rhi/WrapMode.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace liquid::rhi {
+
+enum class WrapMode { Repeat, MirroredRepeat, ClampToEdge, ClampToBorder };
+
+} // namespace liquid::rhi

--- a/engine/rhi/core/src/Descriptor.cpp
+++ b/engine/rhi/core/src/Descriptor.cpp
@@ -16,6 +16,13 @@ Descriptor &Descriptor::write(uint32_t binding,
   return *this;
 }
 
+Descriptor &Descriptor::write(uint32_t binding,
+                              std::span<SamplerHandle> samplers,
+                              uint32_t start) {
+  mNativeDescriptor->write(binding, samplers, start);
+  return *this;
+}
+
 Descriptor &Descriptor::write(uint32_t binding, std::span<BufferHandle> buffers,
                               DescriptorType type, uint32_t start) {
   mNativeDescriptor->write(binding, buffers, type, start);

--- a/engine/rhi/mock/include/liquid/rhi-mock/MockDescriptor.h
+++ b/engine/rhi/mock/include/liquid/rhi-mock/MockDescriptor.h
@@ -31,8 +31,8 @@ public:
     /**
      * Binding data
      */
-    std::variant<std::vector<TextureHandle>, std::vector<BufferHandle>,
-                 std::vector<DescriptorBufferInfo>>
+    std::variant<std::vector<TextureHandle>, std::vector<SamplerHandle>,
+                 std::vector<BufferHandle>, std::vector<DescriptorBufferInfo>>
         data;
   };
 
@@ -54,6 +54,16 @@ public:
    */
   void write(uint32_t binding, std::span<TextureHandle> textures,
              DescriptorType type, uint32_t start) override;
+
+  /**
+   * @brief Bind sampler descriptors
+   *
+   * @param binding Binding number
+   * @param samplers Samplers
+   * @param start Starting index
+   */
+  void write(uint32_t binding, std::span<SamplerHandle> samplers,
+             uint32_t start) override;
 
   /**
    * @brief Bind buffer descriptors

--- a/engine/rhi/mock/include/liquid/rhi-mock/MockRenderDevice.h
+++ b/engine/rhi/mock/include/liquid/rhi-mock/MockRenderDevice.h
@@ -199,6 +199,22 @@ public:
                          TextureHandle handle) override;
 
   /**
+   * @brief Create sampler
+   *
+   * @param description Sampler description
+   * @param handle Sampler handle
+   */
+  void createSampler(const SamplerDescription &description,
+                     SamplerHandle handle) override;
+
+  /**
+   * @brief Destroy sampler
+   *
+   * @param handle Sampler handle
+   */
+  void destroySampler(SamplerHandle handle) override;
+
+  /**
    * @brief Create render pass
    *
    * @param description Render pass description
@@ -317,6 +333,7 @@ public:
 private:
   MockResourceMap<BufferHandle, std::unique_ptr<MockBuffer>> mBuffers;
   MockResourceMap<TextureHandle, MockTexture> mTextures;
+  MockResourceMap<SamplerHandle, SamplerDescription> mSamplers;
   MockResourceMap<FramebufferHandle, FramebufferDescription> mFramebuffers;
   MockResourceMap<RenderPassHandle, RenderPassDescription> mRenderPasses;
 

--- a/engine/rhi/mock/src/MockDescriptor.cpp
+++ b/engine/rhi/mock/src/MockDescriptor.cpp
@@ -16,6 +16,12 @@ void MockDescriptor::write(uint32_t binding, std::span<TextureHandle> textures,
   mBindings.push_back({binding, type, start, vectorFrom(textures)});
 }
 
+void MockDescriptor::write(uint32_t binding, std::span<SamplerHandle> samplers,
+                           uint32_t start) {
+  mBindings.push_back(
+      {binding, DescriptorType::Sampler, start, vectorFrom(samplers)});
+}
+
 void MockDescriptor::write(uint32_t binding, std::span<BufferHandle> buffers,
                            DescriptorType type, uint32_t start) {
   mBindings.push_back({binding, type, start, vectorFrom(buffers)});

--- a/engine/rhi/mock/src/MockRenderDevice.cpp
+++ b/engine/rhi/mock/src/MockRenderDevice.cpp
@@ -98,6 +98,15 @@ void MockRenderDevice::createTexture(const TextureDescription &description,
   return mTextures.insert({description}, handle);
 }
 
+void MockRenderDevice::createSampler(const SamplerDescription &description,
+                                     SamplerHandle handle) {
+  return mSamplers.insert({description}, handle);
+}
+
+void MockRenderDevice::destroySampler(SamplerHandle handle) {
+  mSamplers.erase(handle);
+}
+
 const TextureDescription
 MockRenderDevice::getTextureDescription(TextureHandle handle) const {
   return mTextures.at(handle).getDescription();

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorSet.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanDescriptorSet.h
@@ -35,6 +35,16 @@ public:
              DescriptorType type, uint32_t start) override;
 
   /**
+   * @brief Bind sampler descriptors
+   *
+   * @param binding Binding number
+   * @param samplers Samplers
+   * @param start Starting index
+   */
+  void write(uint32_t binding, std::span<SamplerHandle> samplers,
+             uint32_t start) override;
+
+  /**
    * @brief Write buffers
    *
    * @param binding Binding number
@@ -68,7 +78,7 @@ private:
    * @param bufferInfos Buffer infos
    */
   void write(uint32_t binding, uint32_t start, size_t descriptorCount,
-             DescriptorType type, const VkDescriptorImageInfo *imageInfos,
+             VkDescriptorType type, const VkDescriptorImageInfo *imageInfos,
              VkDescriptorBufferInfo *bufferInfos);
 
 private:

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanMapping.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanMapping.h
@@ -9,6 +9,7 @@
 #include "liquid/rhi/IndexType.h"
 #include "liquid/rhi/Format.h"
 #include "liquid/rhi/Filter.h"
+#include "liquid/rhi/WrapMode.h"
 
 #include "VulkanHeaders.h"
 
@@ -183,6 +184,14 @@ public:
    * @return Vulkan filter
    */
   static VkFilter getFilter(Filter filter);
+
+  /**
+   * @brief Get Vulkan sampler address mode
+   *
+   * @param wrapMode Wrap mode
+   * @return Vulkan sampler address mode
+   */
+  static VkSamplerAddressMode getAddressMode(WrapMode wrapMode);
 
   // Vulkan to RHI mapping
 public:

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanRenderDevice.h
@@ -176,6 +176,22 @@ public:
                          TextureHandle handle) override;
 
   /**
+   * @brief Create sampler
+   *
+   * @param description Sampler description
+   * @param handle Sampler handle
+   */
+  void createSampler(const SamplerDescription &description,
+                     SamplerHandle handle) override;
+
+  /**
+   * @brief Destroy sampler
+   *
+   * @param handle Sampler handle
+   */
+  void destroySampler(SamplerHandle handle) override;
+
+  /**
    * @brief Create render pass
    *
    * @param description Render pass description

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanResourceRegistry.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanResourceRegistry.h
@@ -11,6 +11,7 @@ class VulkanRenderPass;
 class VulkanFramebuffer;
 class VulkanPipeline;
 class VulkanShader;
+class VulkanSampler;
 
 /**
  * @brief Vulkan resource registry
@@ -48,6 +49,7 @@ class VulkanResourceRegistry {
   using ShaderMap = ResourceMap<ShaderHandle, VulkanShader>;
   using BufferMap = ResourceMap<BufferHandle, VulkanBuffer>;
   using TextureMap = ResourceMap<TextureHandle, VulkanTexture>;
+  using SamplerMap = ResourceMap<SamplerHandle, VulkanSampler>;
   using RenderPassMap = ResourceMap<RenderPassHandle, VulkanRenderPass>;
   using FramebufferMap = ResourceMap<FramebufferHandle, VulkanFramebuffer>;
   using PipelineMap = ResourceMap<PipelineHandle, VulkanPipeline>;
@@ -130,6 +132,29 @@ public:
    * @return List of textures
    */
   inline const TextureMap::Map &getTextures() const { return mTextures.map; }
+
+  /**
+   * @brief Set sampler
+   *
+   * @param sampler Vulkan sampler
+   * @param handle Sampler handle
+   */
+  void setSampler(std::unique_ptr<VulkanSampler> &&sampler,
+                  SamplerHandle handle);
+
+  /**
+   * @brief Delete sampler
+   *
+   * @param handle Sampler handle
+   */
+  void deleteSampler(SamplerHandle handle);
+
+  /**
+   * @brief Get samplers
+   *
+   * @return List of samplers
+   */
+  inline const SamplerMap::Map &getSamplers() const { return mSamplers.map; }
 
   /**
    * @brief Set render pass
@@ -218,6 +243,7 @@ public:
 private:
   BufferMap mBuffers;
   TextureMap mTextures;
+  SamplerMap mSamplers;
   ShaderMap mShaders;
   RenderPassMap mRenderPasses;
   FramebufferMap mFramebuffers;

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanSampler.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanSampler.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "liquid/rhi/SamplerDescription.h"
+
+namespace liquid::rhi {
+
+/**
+ * @brief Vulkan sampler
+ *
+ * Manages sampler lifecycle and state
+ */
+class VulkanSampler {
+public:
+  /**
+   * @brief Create Vulkan sampler
+   *
+   * @param description Sampler description
+   * @param device Vulkan device
+   */
+  VulkanSampler(const SamplerDescription &description,
+                VulkanDeviceObject &device);
+
+  /**
+   * @brief Destroy Vulkan sampler
+   */
+  ~VulkanSampler();
+
+  VulkanSampler(const VulkanSampler &) = delete;
+  VulkanSampler &operator=(const VulkanSampler &) = delete;
+  VulkanSampler(VulkanSampler &&) = delete;
+  VulkanSampler &operator=(VulkanSampler &&) = delete;
+
+  /**
+   * @brief Get Vulkan sampler
+   *
+   * @return Vulkan sampler
+   */
+  inline VkSampler getSampler() const { return mSampler; }
+
+private:
+  SamplerDescription mDescription;
+
+  VulkanDeviceObject &mDevice;
+
+  VkSampler mSampler = VK_NULL_HANDLE;
+};
+
+} // namespace liquid::rhi

--- a/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanTexture.h
+++ b/engine/rhi/vulkan/include/liquid/rhi-vulkan/VulkanTexture.h
@@ -79,13 +79,6 @@ public:
   inline VkImageView getImageView() const { return mImageView; }
 
   /**
-   * @brief Get Vulkan sampler
-   *
-   * @return Vulkan sampler
-   */
-  inline VkSampler getSampler() const { return mSampler; }
-
-  /**
    * @brief Get Vulkan allocation
    *
    * @return Vulkan allocation
@@ -119,7 +112,6 @@ private:
   VkFormat mFormat = VK_FORMAT_MAX_ENUM;
   VkImage mImage = VK_NULL_HANDLE;
   VkImageView mImageView = VK_NULL_HANDLE;
-  VkSampler mSampler = VK_NULL_HANDLE;
   VmaAllocation mAllocation = VK_NULL_HANDLE;
   VkImageAspectFlags mAspectFlags = VK_IMAGE_ASPECT_NONE;
   VulkanResourceAllocator &mAllocator;

--- a/engine/rhi/vulkan/src/VulkanMapping.cpp
+++ b/engine/rhi/vulkan/src/VulkanMapping.cpp
@@ -211,16 +211,19 @@ VkVertexInputRate VulkanMapping::getVertexInputRate(VertexInputRate inputRate) {
 VkDescriptorType
 VulkanMapping::getDescriptorType(DescriptorType descriptorType) {
   switch (descriptorType) {
-  case DescriptorType::CombinedImageSampler:
-    return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+  case DescriptorType::SampledImage:
+    return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+  case DescriptorType::Sampler:
+    return VK_DESCRIPTOR_TYPE_SAMPLER;
+  case DescriptorType::StorageImage:
+    return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
   case DescriptorType::UniformBuffer:
     return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
   case DescriptorType::UniformBufferDynamic:
     return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
   case DescriptorType::StorageBuffer:
     return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-  case DescriptorType::StorageImage:
-    return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+
   default:
     return VK_DESCRIPTOR_TYPE_MAX_ENUM;
   }
@@ -336,17 +339,36 @@ VkFilter VulkanMapping::getFilter(Filter filter) {
   }
 }
 
+VkSamplerAddressMode VulkanMapping::getAddressMode(WrapMode wrapMode) {
+  switch (wrapMode) {
+  case WrapMode::Repeat:
+    return VK_SAMPLER_ADDRESS_MODE_REPEAT;
+  case WrapMode::MirroredRepeat:
+    return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+  case WrapMode::ClampToEdge:
+    return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  case WrapMode::ClampToBorder:
+    return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+  default:
+    LIQUID_ASSERT(false, "Wrap mode does not exist");
+    return VK_SAMPLER_ADDRESS_MODE_MAX_ENUM;
+  }
+}
+
 DescriptorType
 VulkanMapping::getDescriptorType(VkDescriptorType descriptorType) {
   switch (descriptorType) {
-  case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-    return DescriptorType::CombinedImageSampler;
+  case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    return DescriptorType::SampledImage;
+  case VK_DESCRIPTOR_TYPE_SAMPLER:
+    return DescriptorType::Sampler;
+  case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    return DescriptorType::StorageImage;
   case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
     return DescriptorType::UniformBuffer;
   case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
     return DescriptorType::StorageBuffer;
-  case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-    return DescriptorType::StorageImage;
+
   default:
     LIQUID_ASSERT(false, "Descriptor type does not exist");
     return DescriptorType::None;

--- a/engine/rhi/vulkan/src/VulkanRenderBackend.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderBackend.cpp
@@ -10,6 +10,7 @@
 #include "VulkanFramebuffer.h"
 #include "VulkanPipeline.h"
 #include "VulkanShader.h"
+#include "VulkanSampler.h"
 #include <GLFW/glfw3.h>
 #include "VulkanRenderDevice.h"
 #include "VulkanError.h"

--- a/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
@@ -5,6 +5,7 @@
 #include "VulkanRenderDevice.h"
 #include "VulkanDeviceObject.h"
 #include "VulkanTexture.h"
+#include "VulkanSampler.h"
 #include "VulkanBuffer.h"
 #include "VulkanRenderPass.h"
 #include "VulkanFramebuffer.h"
@@ -173,6 +174,16 @@ void VulkanRenderDevice::createTexture(const TextureDescription &description,
   mRegistry.setTexture(
       std::make_unique<VulkanTexture>(description, mAllocator, mDevice),
       handle);
+}
+
+void VulkanRenderDevice::createSampler(const SamplerDescription &description,
+                                       SamplerHandle handle) {
+  mRegistry.setSampler(std::make_unique<VulkanSampler>(description, mDevice),
+                       handle);
+}
+
+void VulkanRenderDevice::destroySampler(SamplerHandle handle) {
+  mRegistry.deleteSampler(handle);
 }
 
 const TextureDescription

--- a/engine/rhi/vulkan/src/VulkanResourceRegistry.cpp
+++ b/engine/rhi/vulkan/src/VulkanResourceRegistry.cpp
@@ -2,6 +2,7 @@
 
 #include "VulkanResourceRegistry.h"
 #include "VulkanTexture.h"
+#include "VulkanSampler.h"
 #include "VulkanBuffer.h"
 #include "VulkanRenderPass.h"
 #include "VulkanFramebuffer.h"
@@ -35,6 +36,15 @@ void VulkanResourceRegistry::deleteBuffer(BufferHandle handle) {
 void VulkanResourceRegistry::setTexture(
     std::unique_ptr<VulkanTexture> &&texture, TextureHandle handle) {
   mTextures.map.insert_or_assign(handle, std::move(texture));
+}
+
+void VulkanResourceRegistry::setSampler(
+    std::unique_ptr<VulkanSampler> &&sampler, SamplerHandle handle) {
+  mSamplers.map.insert_or_assign(handle, std::move(sampler));
+}
+
+void VulkanResourceRegistry::deleteSampler(SamplerHandle handle) {
+  mSamplers.map.erase(handle);
 }
 
 void VulkanResourceRegistry::deleteTexture(TextureHandle handle) {

--- a/engine/rhi/vulkan/src/VulkanSampler.cpp
+++ b/engine/rhi/vulkan/src/VulkanSampler.cpp
@@ -1,0 +1,41 @@
+#include "liquid/core/Base.h"
+
+#include "VulkanHeaders.h"
+#include "VulkanDeviceObject.h"
+#include "VulkanSampler.h"
+#include "VulkanError.h"
+#include "VulkanMapping.h"
+
+namespace liquid::rhi {
+
+VulkanSampler::VulkanSampler(const SamplerDescription &description,
+                             VulkanDeviceObject &device)
+    : mDescription(description), mDevice(device) {
+  VkSamplerCreateInfo createInfo{};
+  createInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+  createInfo.flags = 0;
+  createInfo.pNext = nullptr;
+  createInfo.minFilter = VulkanMapping::getFilter(description.minFilter);
+  createInfo.magFilter = VulkanMapping::getFilter(description.magFilter);
+  createInfo.addressModeU =
+      VulkanMapping::getAddressMode(description.wrapModeU);
+  createInfo.addressModeV =
+      VulkanMapping::getAddressMode(description.wrapModeV);
+  createInfo.addressModeW =
+      VulkanMapping::getAddressMode(description.wrapModeW);
+  createInfo.minLod = description.minLod;
+  createInfo.maxLod =
+      description.maxLod == 0.0f ? VK_LOD_CLAMP_NONE : description.maxLod;
+
+  checkForVulkanError(vkCreateSampler(mDevice, &createInfo, nullptr, &mSampler),
+                      "Failed to create sampler", description.debugName);
+
+  mDevice.setObjectName(description.debugName + " sampler",
+                        VK_OBJECT_TYPE_SAMPLER, static_cast<void *>(mSampler));
+}
+
+VulkanSampler::~VulkanSampler() {
+  vkDestroySampler(mDevice, mSampler, nullptr);
+}
+
+} // namespace liquid::rhi

--- a/engine/rhi/vulkan/src/VulkanTexture.cpp
+++ b/engine/rhi/vulkan/src/VulkanTexture.cpp
@@ -12,7 +12,7 @@ VulkanTexture::VulkanTexture(VkImage image, VkImageView imageView,
                              VulkanResourceAllocator &allocator,
                              VulkanDeviceObject &device)
     : mAllocator(allocator), mDevice(device), mImage(image),
-      mImageView(imageView), mSampler(sampler), mFormat(format) {
+      mImageView(imageView), mFormat(format) {
 
   // Note: This constructor is ONLY used
   // for defining swapchain; so, its usage
@@ -135,24 +135,6 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
 
   mDevice.setObjectName(description.debugName, VK_OBJECT_TYPE_IMAGE_VIEW,
                         mImageView);
-
-  VkSamplerCreateInfo samplerCreateInfo{};
-  samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-  samplerCreateInfo.pNext = nullptr;
-  samplerCreateInfo.flags = 0;
-  samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-  samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-  samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-  samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
-  samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
-  samplerCreateInfo.minLod = 0.0f;
-  samplerCreateInfo.maxLod = VK_LOD_CLAMP_NONE;
-  checkForVulkanError(
-      vkCreateSampler(mDevice, &samplerCreateInfo, nullptr, &mSampler),
-      "Failed to image sampler", description.debugName);
-
-  mDevice.setObjectName(description.debugName, VK_OBJECT_TYPE_SAMPLER,
-                        mSampler);
 }
 
 VulkanTexture::VulkanTexture(const TextureViewDescription &description,
@@ -196,31 +178,9 @@ VulkanTexture::VulkanTexture(const TextureViewDescription &description,
 
   mDevice.setObjectName(description.debugName, VK_OBJECT_TYPE_IMAGE_VIEW,
                         mImageView);
-
-  VkSamplerCreateInfo samplerCreateInfo{};
-  samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-  samplerCreateInfo.pNext = nullptr;
-  samplerCreateInfo.flags = 0;
-  samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-  samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-  samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-  samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
-  samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
-  samplerCreateInfo.minLod = 0.0f;
-  samplerCreateInfo.maxLod = VK_LOD_CLAMP_NONE;
-  checkForVulkanError(
-      vkCreateSampler(mDevice, &samplerCreateInfo, nullptr, &mSampler),
-      "Failed to image sampler", description.debugName);
-
-  mDevice.setObjectName(description.debugName, VK_OBJECT_TYPE_SAMPLER,
-                        mSampler);
 }
 
 VulkanTexture::~VulkanTexture() {
-  if (mSampler) {
-    vkDestroySampler(mDevice, mSampler, nullptr);
-  }
-
   if (mImageView) {
     vkDestroyImageView(mDevice, mImageView, nullptr);
   }

--- a/engine/rhi/vulkan/src/VulkanValidator.cpp
+++ b/engine/rhi/vulkan/src/VulkanValidator.cpp
@@ -85,8 +85,9 @@ static String getValidationMessage(
   ss << "\n\t"
      << "Message ID: " << pCallbackData->pMessageIdName;
   for (uint32_t i = 0; i < pCallbackData->objectCount; ++i) {
+    const char *name = pCallbackData->pObjects[i].pObjectName;
     ss << "\n\t"
-       << "Object: " << pCallbackData->pObjects[i].pObjectName;
+       << "Object: " << (name ? name : "[no name]");
   }
 
   return ss.str();

--- a/engine/src/liquid/imgui/ImguiRenderer.cpp
+++ b/engine/src/liquid/imgui/ImguiRenderer.cpp
@@ -246,7 +246,8 @@ void ImguiRenderer::draw(rhi::RenderCommandList &commandList,
         commandList.bindPipeline(pipeline);
 
         glm::uvec4 textureData{
-            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(cmd->TextureId))};
+            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(cmd->TextureId)),
+            rhi::castHandleToUint(mRenderStorage.getDefaultSampler()), 0, 0};
 
         commandList.pushConstants(pipeline, rhi::ShaderStage::Fragment,
                                   sizeof(glm::mat4), sizeof(glm::uvec4),

--- a/engine/src/liquid/renderer/RenderStorage.cpp
+++ b/engine/src/liquid/renderer/RenderStorage.cpp
@@ -15,36 +15,36 @@ RenderStorage::RenderStorage(rhi::RenderDevice *device) : mDevice(device) {
     binding0.type = rhi::DescriptorLayoutBindingType::Dynamic;
     binding0.name = "uGlobalTextures";
     binding0.descriptorCount = NumSamplers;
-    binding0.descriptorType = rhi::DescriptorType::CombinedImageSampler;
+    binding0.descriptorType = rhi::DescriptorType::SampledImage;
     binding0.shaderStage = rhi::ShaderStage::All;
 
     rhi::DescriptorLayoutBindingDescription binding1{};
     binding1.binding = 1;
     binding1.type = rhi::DescriptorLayoutBindingType::Dynamic;
-    binding1.name = "uGlobalImages";
+    binding1.name = "uGlobalSamplers";
     binding1.descriptorCount = NumSamplers;
-    binding1.descriptorType = rhi::DescriptorType::StorageImage;
+    binding1.descriptorType = rhi::DescriptorType::Sampler;
     binding1.shaderStage = rhi::ShaderStage::All;
 
-    rhi::DescriptorLayoutDescription description{{binding0, binding1},
+    rhi::DescriptorLayoutBindingDescription binding2{};
+    binding2.binding = 2;
+    binding2.type = rhi::DescriptorLayoutBindingType::Dynamic;
+    binding2.name = "uGlobalImages";
+    binding2.descriptorCount = NumSamplers;
+    binding2.descriptorType = rhi::DescriptorType::StorageImage;
+    binding2.shaderStage = rhi::ShaderStage::All;
+
+    rhi::DescriptorLayoutDescription description{{binding0, binding1, binding2},
                                                  "Global textures"};
     auto layout = mDevice->createDescriptorLayout(description);
 
     mGlobalTexturesDescriptor = mDevice->createDescriptor(layout);
   }
 
-  // Material descriptor layout
   {
-    rhi::DescriptorLayoutBindingDescription binding{};
-    binding.binding = 0;
-    binding.type = rhi::DescriptorLayoutBindingType::Static;
-    binding.name = "uMaterialDataRaw";
-    binding.descriptorCount = 1;
-    binding.descriptorType = rhi::DescriptorType::UniformBuffer;
-    binding.shaderStage = rhi::ShaderStage::Fragment;
-
-    rhi::DescriptorLayoutDescription description{{binding}, "Material"};
-    mMaterialDescriptorLayout = mDevice->createDescriptorLayout(description);
+    rhi::SamplerDescription description{};
+    description.debugName = "default";
+    mDefaultSampler = createSampler(description);
   }
 }
 
@@ -68,6 +68,20 @@ RenderStorage::createTextureView(const rhi::TextureViewDescription &description,
   auto handle = getNewTextureHandle();
 
   mDevice->createTextureView(description, handle);
+
+  if (addToDescriptor) {
+    this->addToDescriptor(handle);
+  }
+
+  return handle;
+}
+
+rhi::SamplerHandle
+RenderStorage::createSampler(const rhi::SamplerDescription &description,
+                             bool addToDescriptor) {
+  auto handle = mSamplerCounter.create();
+
+  mDevice->createSampler(description, handle);
 
   if (addToDescriptor) {
     this->addToDescriptor(handle);
@@ -101,15 +115,21 @@ void RenderStorage::addToDescriptor(rhi::TextureHandle handle) {
 
   if (BitwiseEnumContains(usage, rhi::TextureUsage::Sampled)) {
     mGlobalTexturesDescriptor.write(0, textures,
-                                    rhi::DescriptorType::CombinedImageSampler,
+                                    rhi::DescriptorType::SampledImage,
                                     rhi::castHandleToUint(handle));
   }
 
   if (BitwiseEnumContains(usage, rhi::TextureUsage::Storage)) {
-    mGlobalTexturesDescriptor.write(1, textures,
+    mGlobalTexturesDescriptor.write(2, textures,
                                     rhi::DescriptorType::StorageImage,
                                     rhi::castHandleToUint(handle));
   }
+}
+
+void RenderStorage::addToDescriptor(rhi::SamplerHandle handle) {
+  std::array<rhi::SamplerHandle, 1> samplers{handle};
+
+  mGlobalTexturesDescriptor.write(1, samplers, rhi::castHandleToUint(handle));
 }
 
 rhi::TextureHandle RenderStorage::getNewTextureHandle() {
@@ -127,14 +147,6 @@ rhi::FramebufferHandle RenderStorage::getNewFramebufferHandle() {
 rhi::Buffer
 RenderStorage::createBuffer(const rhi::BufferDescription &description) {
   return mDevice->createBuffer(description);
-}
-
-rhi::Descriptor RenderStorage::createMaterialDescriptor(rhi::Buffer buffer) {
-  auto descriptor = mDevice->createDescriptor(mMaterialDescriptorLayout);
-  std::array<rhi::BufferHandle, 1> buffers{buffer.getHandle()};
-  descriptor.write(0, buffers, rhi::DescriptorType::UniformBuffer, 0);
-
-  return descriptor;
 }
 
 rhi::PipelineHandle RenderStorage::addPipeline(

--- a/engine/src/liquid/renderer/RenderStorage.h
+++ b/engine/src/liquid/renderer/RenderStorage.h
@@ -38,9 +38,8 @@ public:
    * @param addToDescriptor Add texture to global descriptor
    * @return Texture handle
    */
-  rhi::TextureHandle
-  createTexture(const liquid::rhi::TextureDescription &description,
-                bool addToDescriptor = true);
+  rhi::TextureHandle createTexture(const rhi::TextureDescription &description,
+                                   bool addToDescriptor = true);
 
   /**
    * @brief Create texture view
@@ -50,8 +49,18 @@ public:
    * @return Texture view handle
    */
   rhi::TextureHandle
-  createTextureView(const liquid::rhi::TextureViewDescription &description,
+  createTextureView(const rhi::TextureViewDescription &description,
                     bool addToDescriptor = true);
+
+  /**
+   * @brief Create sampler
+   *
+   * @param description Sampler description
+   * @param addToDescriptor Add sampler to global descriptor
+   * @return Sampler handle
+   */
+  rhi::SamplerHandle createSampler(const rhi::SamplerDescription &description,
+                                   bool addToDescriptor = true);
 
   /**
    * @brief Destroy texture
@@ -67,9 +76,8 @@ public:
    * @param description Shader description
    * @return Shader handle
    */
-  rhi::ShaderHandle
-  createShader(const String &name,
-               const liquid::rhi::ShaderDescription &description);
+  rhi::ShaderHandle createShader(const String &name,
+                                 const rhi::ShaderDescription &description);
 
   /**
    * @brief Get shader by name
@@ -85,6 +93,13 @@ public:
    * @param handle Texture handle
    */
   void addToDescriptor(rhi::TextureHandle handle);
+
+  /**
+   * @brief Add sampler to global descriptor
+   *
+   * @param handle Sampler handle
+   */
+  void addToDescriptor(rhi::SamplerHandle handle);
 
   /**
    * @brief Get new texture handle
@@ -113,7 +128,7 @@ public:
    * @param description Buffer description
    * @return Buffer
    */
-  rhi::Buffer createBuffer(const liquid::rhi::BufferDescription &description);
+  rhi::Buffer createBuffer(const rhi::BufferDescription &description);
 
   /**
    * @brief Get global textures descriptor
@@ -125,12 +140,13 @@ public:
   }
 
   /**
-   * @brief Create material descriptor
+   * @brief Get default sampler
    *
-   * @param buffer Material buffer
-   * @return Material descriptor
+   * @return Default sampler
    */
-  rhi::Descriptor createMaterialDescriptor(rhi::Buffer buffer);
+  inline rhi::SamplerHandle getDefaultSampler() const {
+    return mDefaultSampler;
+  }
 
   /**
    * @brief Get render device
@@ -185,8 +201,6 @@ public:
 private:
   rhi::RenderDevice *mDevice = nullptr;
 
-  rhi::DescriptorLayoutHandle mMaterialDescriptorLayout{0};
-
   rhi::Descriptor mGlobalTexturesDescriptor;
 
   std::vector<std::variant<rhi::GraphicsPipelineDescription,
@@ -200,6 +214,9 @@ private:
   HandleCounter<rhi::TextureHandle, TextureStart> mTextureCounter;
   HandleCounter<rhi::RenderPassHandle> mRenderPassCounter;
   HandleCounter<rhi::FramebufferHandle> mFramebufferCounter;
+  HandleCounter<rhi::SamplerHandle> mSamplerCounter;
+
+  rhi::SamplerHandle mDefaultSampler = rhi::SamplerHandle::Null;
 
   std::unordered_map<String, rhi::ShaderHandle> mShaderMap;
 };

--- a/engine/src/liquid/renderer/SceneRenderer.h
+++ b/engine/src/liquid/renderer/SceneRenderer.h
@@ -194,6 +194,8 @@ private:
   RenderStorage &mRenderStorage;
   std::array<SceneRendererFrameData, rhi::RenderDevice::NumFrames> mFrameData;
 
+  rhi::SamplerHandle mBloomSampler;
+
   uint32_t mMaxSampleCounts = 1;
 };
 


### PR DESCRIPTION
- Add sampler description
- Create sampler in render device
- Allow binding samplers as descriptors
- Add binding slot for samplers in all shaders
- Replace combined image sampler with texture and sampler
- Remove samplers from texture