### PR TITLE
Load assets using uuids

### DIFF
--- a/editor/src/liquidator/asset/AssetManager.cpp
+++ b/editor/src/liquidator/asset/AssetManager.cpp
@@ -325,13 +325,13 @@ Result<UUIDMap> AssetManager::loadSourceTexture(const Path &sourceAssetPath,
   int32_t channels = 0;
 
   if (sourceAssetPath.extension() == ".ktx2") {
-    auto createRes = mAssetCache.createTextureFromSource(
-        sourceAssetPath, getUUIDFromMap(uuids, "root"));
+    auto uuid = getOrCreateUuidFromMap(uuids, "root");
+    auto createRes = mAssetCache.createTextureFromSource(sourceAssetPath, uuid);
     if (!createRes.hasData()) {
       return Result<UUIDMap>::Error(createRes.getError());
     }
 
-    auto res = mAssetCache.loadTextureFromFile(createRes.getData());
+    auto res = mAssetCache.loadTexture(uuid);
 
     if (res.hasData()) {
       auto uuid =
@@ -342,9 +342,9 @@ Result<UUIDMap> AssetManager::loadSourceTexture(const Path &sourceAssetPath,
     return Result<UUIDMap>::Error(res.getError());
   }
 
-  auto uuid =
-      mImageLoader.loadFromPath(sourceAssetPath, getUUIDFromMap(uuids, "root"),
-                                mOptimize, rhi::Format::Rgba8Srgb);
+  auto uuid = mImageLoader.loadFromPath(sourceAssetPath,
+                                        getOrCreateUuidFromMap(uuids, "root"),
+                                        mOptimize, rhi::Format::Rgba8Srgb);
 
   if (uuid.hasError()) {
     return Result<UUIDMap>::Error(uuid.getError());
@@ -355,17 +355,15 @@ Result<UUIDMap> AssetManager::loadSourceTexture(const Path &sourceAssetPath,
 
 Result<UUIDMap> AssetManager::loadSourceAudio(const Path &sourceAssetPath,
                                               const UUIDMap &uuids) {
-  auto createRes = mAssetCache.createAudioFromSource(
-      sourceAssetPath, getUUIDFromMap(uuids, "root"));
+  auto uuid = getOrCreateUuidFromMap(uuids, "root");
+  auto createRes = mAssetCache.createAudioFromSource(sourceAssetPath, uuid);
   if (!createRes.hasData()) {
     return Result<UUIDMap>::Error(createRes.getError());
   }
 
-  auto res = mAssetCache.loadAudioFromFile(createRes.getData());
+  auto res = mAssetCache.loadAudio(uuid);
 
   if (res.hasData()) {
-    auto uuid =
-        mAssetCache.getRegistry().getAudios().getAsset(res.getData()).uuid;
     return Result<UUIDMap>::Ok({{"root", uuid}});
   }
 
@@ -374,13 +372,13 @@ Result<UUIDMap> AssetManager::loadSourceAudio(const Path &sourceAssetPath,
 
 Result<UUIDMap> AssetManager::loadSourceScript(const Path &sourceAssetPath,
                                                const UUIDMap &uuids) {
-  auto createRes = mAssetCache.createLuaScriptFromSource(
-      sourceAssetPath, getUUIDFromMap(uuids, "root"));
+  auto uuid = getOrCreateUuidFromMap(uuids, "root");
+  auto createRes = mAssetCache.createLuaScriptFromSource(sourceAssetPath, uuid);
   if (!createRes.hasData()) {
     return Result<UUIDMap>::Error(createRes.getError());
   }
 
-  auto res = mAssetCache.loadLuaScriptFromFile(createRes.getData());
+  auto res = mAssetCache.loadLuaScript(uuid);
 
   if (res.hasData()) {
     auto uuid =
@@ -393,13 +391,13 @@ Result<UUIDMap> AssetManager::loadSourceScript(const Path &sourceAssetPath,
 
 Result<UUIDMap> AssetManager::loadSourceFont(const Path &sourceAssetPath,
                                              const UUIDMap &uuids) {
-  auto createRes = mAssetCache.createFontFromSource(
-      sourceAssetPath, getUUIDFromMap(uuids, "root"));
+  auto uuid = getOrCreateUuidFromMap(uuids, "root");
+  auto createRes = mAssetCache.createFontFromSource(sourceAssetPath, uuid);
   if (!createRes.hasData()) {
     return Result<UUIDMap>::Error(createRes.getError());
   }
 
-  auto res = mAssetCache.loadFontFromFile(createRes.getData());
+  auto res = mAssetCache.loadFont(uuid);
 
   if (res.hasData()) {
     auto uuid =
@@ -412,13 +410,13 @@ Result<UUIDMap> AssetManager::loadSourceFont(const Path &sourceAssetPath,
 
 Result<UUIDMap> AssetManager::loadSourceAnimator(const Path &sourceAssetPath,
                                                  const UUIDMap &uuids) {
-  auto createRes = mAssetCache.createAnimatorFromSource(
-      sourceAssetPath, getUUIDFromMap(uuids, "root"));
+  auto uuid = getOrCreateUuidFromMap(uuids, "root");
+  auto createRes = mAssetCache.createAnimatorFromSource(sourceAssetPath, uuid);
   if (!createRes.hasData()) {
     return Result<UUIDMap>::Error(createRes.getError());
   }
 
-  auto res = mAssetCache.loadAnimatorFromFile(createRes.getData());
+  auto res = mAssetCache.loadAnimator(uuid);
 
   if (res.hasData()) {
     auto uuid =
@@ -442,17 +440,15 @@ Result<UUIDMap> AssetManager::loadSourceEnvironment(const Path &sourceAssetPath,
 
 Result<UUIDMap> AssetManager::loadSourceScene(const Path &sourceAssetPath,
                                               const UUIDMap &uuids) {
-  auto createRes = mAssetCache.createSceneFromSource(
-      sourceAssetPath, getUUIDFromMap(uuids, "root"));
+  auto uuid = getOrCreateUuidFromMap(uuids, "root");
+  auto createRes = mAssetCache.createSceneFromSource(sourceAssetPath, uuid);
   if (!createRes.hasData()) {
     return Result<UUIDMap>::Error(createRes.getError());
   }
 
-  auto res = mAssetCache.loadSceneFromFile(createRes.getData());
+  auto res = mAssetCache.loadScene(uuid);
 
   if (res.hasData()) {
-    auto uuid =
-        mAssetCache.getRegistry().getScenes().getAsset(res.getData()).uuid;
     return Result<UUIDMap>::Ok({{"root", uuid}});
   }
 

--- a/editor/src/liquidator/asset/HDRIImporter.cpp
+++ b/editor/src/liquidator/asset/HDRIImporter.cpp
@@ -116,7 +116,7 @@ Result<UUIDMap> HDRIImporter::loadFromPath(const Path &sourceAssetPath,
 
   auto irradianceMapName = sourceAssetPath.filename().string() + "/irradiance";
   auto irradianceCubemap = generateIrradianceMap(
-      unfilteredCubemap, getUUIDFromMap(uuids, "irradiance"),
+      unfilteredCubemap, getOrCreateUuidFromMap(uuids, "irradiance"),
       irradianceMapName);
 
   if (irradianceCubemap.hasError()) {
@@ -126,7 +126,8 @@ Result<UUIDMap> HDRIImporter::loadFromPath(const Path &sourceAssetPath,
 
   auto specularMapName = sourceAssetPath.filename().string() + "/specular";
   auto specularCubemap = generateSpecularMap(
-      unfilteredCubemap, getUUIDFromMap(uuids, "specular"), specularMapName);
+      unfilteredCubemap, getOrCreateUuidFromMap(uuids, "specular"),
+      specularMapName);
 
   if (specularCubemap.hasError()) {
     device->destroyTexture(unfilteredCubemap.texture);
@@ -139,7 +140,7 @@ Result<UUIDMap> HDRIImporter::loadFromPath(const Path &sourceAssetPath,
   device->destroyTexture(unfilteredCubemap.texture);
 
   AssetData<EnvironmentAsset> environment{};
-  environment.uuid = getUUIDFromMap(uuids, "root");
+  environment.uuid = getOrCreateUuidFromMap(uuids, "root");
   environment.data.specularMap = specularCubemap.getData();
   environment.data.irradianceMap = irradianceCubemap.getData();
 
@@ -149,7 +150,7 @@ Result<UUIDMap> HDRIImporter::loadFromPath(const Path &sourceAssetPath,
     return Result<UUIDMap>::Error(createdFileRes.getError());
   }
 
-  auto loadRes = mAssetCache.loadEnvironmentFromFile(createdFileRes.getData());
+  auto loadRes = mAssetCache.loadEnvironment(environment.uuid);
   if (loadRes.hasError()) {
     return Result<UUIDMap>::Error(loadRes.getError());
   }
@@ -387,7 +388,7 @@ HDRIImporter::generateIrradianceMap(const CubemapData &unfilteredCubemap,
     return Result<TextureAssetHandle>::Error(createdFileRes.getError());
   }
 
-  return mAssetCache.loadTextureFromFile(createdFileRes.getData());
+  return mAssetCache.loadTexture(asset.uuid);
 }
 
 Result<TextureAssetHandle>
@@ -481,7 +482,7 @@ HDRIImporter::generateSpecularMap(const CubemapData &unfilteredCubemap,
     return Result<TextureAssetHandle>::Error(createdFileRes.getError());
   }
 
-  return mAssetCache.loadTextureFromFile(createdFileRes.getData());
+  return mAssetCache.loadTexture(asset.uuid);
 }
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/asset/ImageLoader.cpp
+++ b/editor/src/liquidator/asset/ImageLoader.cpp
@@ -96,7 +96,7 @@ Result<Uuid> ImageLoader::loadFromMemory(void *data, uint32_t width,
     return Result<Uuid>::Error(createdFileRes.getError());
   }
 
-  auto loadRes = mAssetCache.loadTextureFromFile(createdFileRes.getData());
+  auto loadRes = mAssetCache.loadTexture(asset.uuid);
   if (loadRes.hasError()) {
     return Result<Uuid>::Error(loadRes.getError());
   }

--- a/editor/src/liquidator/asset/UUIDMap.cpp
+++ b/editor/src/liquidator/asset/UUIDMap.cpp
@@ -3,13 +3,13 @@
 
 namespace liquid::editor {
 
-Uuid getUUIDFromMap(const UUIDMap &uuids, const String &key) {
+Uuid getOrCreateUuidFromMap(const UUIDMap &uuids, const String &key) {
   auto it = uuids.find(key);
   if (it != uuids.end()) {
     return it->second;
   }
 
-  return Uuid{};
+  return Uuid::generate();
 }
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/asset/UUIDMap.h
+++ b/editor/src/liquidator/asset/UUIDMap.h
@@ -9,8 +9,8 @@ using UUIDMap = std::unordered_map<String, Uuid>;
  *
  * @param uuids Uuid map
  * @param key Uuid map key
- * @return Uuid or empty uuid
+ * @return Uuid
  */
-Uuid getUUIDFromMap(const UUIDMap &uuids, const String &key);
+Uuid getOrCreateUuidFromMap(const UUIDMap &uuids, const String &key);
 
 } // namespace liquid::editor

--- a/editor/src/liquidator/asset/gltf/AnimationStep.cpp
+++ b/editor/src/liquidator/asset/gltf/AnimationStep.cpp
@@ -124,7 +124,7 @@ void loadAnimations(GLTFImportData &importData) {
     AssetData<AnimationAsset> animation;
     animation.name = getGLTFAssetName(importData, assetName);
     animation.data.time = maxTime;
-    animation.uuid = getUUID(importData, assetName);
+    animation.uuid = getOrCreateGLTFUuid(importData, assetName);
 
     int32_t targetNode = -1;
     int32_t targetSkin = -1;
@@ -225,7 +225,7 @@ void loadAnimations(GLTFImportData &importData) {
     }
 
     auto filePath = assetCache.createAnimationFromAsset(animation);
-    auto handle = assetCache.loadAnimationFromFile(filePath.getData());
+    auto handle = assetCache.loadAnimation(animation.uuid);
     importData.outputUuids.insert_or_assign(assetName,
                                             assetCache.getRegistry()
                                                 .getAnimations()
@@ -254,7 +254,7 @@ void loadAnimations(GLTFImportData &importData) {
 
     AssetData<AnimatorAsset> asset{};
     asset.name = getGLTFAssetName(importData, animatorName);
-    asset.uuid = getUUID(importData, animatorName);
+    asset.uuid = getOrCreateGLTFUuid(importData, animatorName);
 
     for (auto [handle, assetName] : animations) {
       AnimationState state{};
@@ -281,7 +281,7 @@ void loadAnimations(GLTFImportData &importData) {
     }
 
     auto path = assetCache.createAnimatorFromAsset(asset);
-    auto handle = assetCache.loadAnimatorFromFile(path.getData());
+    auto handle = assetCache.loadAnimator(asset.uuid);
     importData.animations.skinAnimatorMap.insert_or_assign(skin,
                                                            handle.getData());
 
@@ -322,7 +322,7 @@ void loadAnimations(GLTFImportData &importData) {
     }
 
     auto path = assetCache.createAnimatorFromAsset(asset);
-    auto handle = assetCache.loadAnimatorFromFile(path.getData());
+    auto handle = assetCache.loadAnimator(asset.uuid);
     importData.animations.nodeAnimatorMap.insert_or_assign(node,
                                                            handle.getData());
     importData.outputUuids.insert_or_assign(animatorName,

--- a/editor/src/liquidator/asset/gltf/GLTFImportData.h
+++ b/editor/src/liquidator/asset/gltf/GLTFImportData.h
@@ -160,10 +160,11 @@ struct GLTFImportData {
  *
  * @param importData Import data
  * @param name Asset name
- * @return Uuid or empty uuid
+ * @return Uuid
  */
-static Uuid getUUID(const GLTFImportData &importData, const String &name) {
-  return getUUIDFromMap(importData.uuids, name);
+static Uuid getOrCreateGLTFUuid(const GLTFImportData &importData,
+                                const String &name) {
+  return getOrCreateUuidFromMap(importData.uuids, name);
 }
 
 /**

--- a/editor/src/liquidator/asset/gltf/MaterialStep.cpp
+++ b/editor/src/liquidator/asset/gltf/MaterialStep.cpp
@@ -25,7 +25,7 @@ void loadMaterials(GLTFImportData &importData) {
     AssetData<MaterialAsset> material;
 
     material.name = getGLTFAssetName(importData, assetName);
-    material.uuid = getUUID(importData, assetName);
+    material.uuid = getOrCreateGLTFUuid(importData, assetName);
     material.type = AssetType::Material;
 
     if (gltfMaterial.pbrMetallicRoughness.baseColorTexture.index >= 0) {
@@ -96,7 +96,7 @@ void loadMaterials(GLTFImportData &importData) {
     }
 
     auto path = assetCache.createMaterialFromAsset(material);
-    auto handle = assetCache.loadMaterialFromFile(path.getData());
+    auto handle = assetCache.loadMaterial(material.uuid);
     importData.materials.map.insert_or_assign(i, handle.getData());
 
     importData.outputUuids.insert_or_assign(assetName,

--- a/editor/src/liquidator/asset/gltf/MeshStep.cpp
+++ b/editor/src/liquidator/asset/gltf/MeshStep.cpp
@@ -476,11 +476,11 @@ void loadMeshes(GLTFImportData &importData) {
 
     mesh.type = isSkinnedMesh ? AssetType::SkinnedMesh : AssetType::Mesh;
     mesh.name = getGLTFAssetName(importData, assetName);
-    mesh.uuid = getUUID(importData, assetName);
+    mesh.uuid = getOrCreateGLTFUuid(importData, assetName);
 
     auto path = assetCache.createMeshFromAsset(mesh);
 
-    auto handle = assetCache.loadMeshFromFile(path.getData());
+    auto handle = assetCache.loadMesh(mesh.uuid);
     importData.meshes.map.insert_or_assign(i, handle.getData());
 
     importData.meshMaterials.insert_or_assign(handle.getData(), materials);

--- a/editor/src/liquidator/asset/gltf/PrefabStep.cpp
+++ b/editor/src/liquidator/asset/gltf/PrefabStep.cpp
@@ -17,7 +17,7 @@ void loadPrefabs(GLTFImportData &importData) {
   AssetData<PrefabAsset> prefab;
   prefab.name = importData.sourcePath.filename().string();
   prefab.type = AssetType::Prefab;
-  prefab.uuid = getUUID(importData, "root");
+  prefab.uuid = getOrCreateGLTFUuid(importData, "root");
 
   auto &gltfNodes = model.scenes.at(model.defaultScene);
 
@@ -135,7 +135,7 @@ void loadPrefabs(GLTFImportData &importData) {
   auto path = assetCache.createPrefabFromAsset(prefab);
 
   if (path.hasData()) {
-    auto handle = assetCache.loadPrefabFromFile(path.getData());
+    auto handle = assetCache.loadPrefab(prefab.uuid);
 
     if (handle.hasData()) {
       importData.outputUuids.insert_or_assign("root",

--- a/editor/src/liquidator/asset/gltf/SkeletonStep.cpp
+++ b/editor/src/liquidator/asset/gltf/SkeletonStep.cpp
@@ -107,7 +107,7 @@ void loadSkeletons(GLTFImportData &importData) {
     AssetData<SkeletonAsset> asset;
     asset.name = getGLTFAssetName(importData, assetName);
     asset.type = AssetType::Skeleton;
-    asset.uuid = getUUID(importData, skeletonName);
+    asset.uuid = getOrCreateGLTFUuid(importData, skeletonName);
 
     for (auto &joint : skin.joints) {
       uint32_t nJoint = normalizedJointMap.at(joint);
@@ -125,7 +125,7 @@ void loadSkeletons(GLTFImportData &importData) {
     }
 
     auto path = assetCache.createSkeletonFromAsset(asset);
-    auto handle = assetCache.loadSkeletonFromFile(path.getData());
+    auto handle = assetCache.loadSkeleton(asset.uuid);
 
     importData.skeletons.skeletonMap.map.insert_or_assign(
         static_cast<size_t>(si), handle.getData());

--- a/editor/src/liquidator/asset/gltf/TextureUtils.cpp
+++ b/editor/src/liquidator/asset/gltf/TextureUtils.cpp
@@ -33,7 +33,7 @@ TextureAssetHandle loadTexture(GLTFImportData &importData, size_t index,
     return TextureAssetHandle::Null;
   }
 
-  auto prevUuid = getUUIDFromMap(importData.uuids, assetName);
+  auto prevUuid = getOrCreateUuidFromMap(importData.uuids, assetName);
 
   auto uuid = importData.imageLoader.loadFromMemory(
       const_cast<void *>(static_cast<const void *>(image.image.data())),

--- a/editor/tests/liquidator-tests/asset/AssetManager.test.cpp
+++ b/editor/tests/liquidator-tests/asset/AssetManager.test.cpp
@@ -224,7 +224,7 @@ TEST_P(AssetTest, ImportCreatesAssetInCache) {
   EXPECT_TRUE(uuid.isValid());
 
   EXPECT_EQ(
-      manager.getCache().getMetaFromUuid(uuid).type,
+      manager.getCache().getAssetMeta(uuid).type,
       liquid::editor::AssetManager::getAssetTypeFromExtension(res.getData()));
 }
 

--- a/engine/src/liquid/asset/AssetCache.cpp
+++ b/engine/src/liquid/asset/AssetCache.cpp
@@ -69,7 +69,7 @@ Result<bool> AssetCache::loadAsset(const Path &path) {
   return loadAsset(path, true);
 }
 
-AssetMeta AssetCache::getMetaFromUuid(const Uuid &uuid) const {
+AssetMeta AssetCache::getAssetMeta(const Uuid &uuid) const {
   AssetMeta meta{};
   auto typePath =
       (mAssetsPath / uuid.toString()).replace_extension("assetmeta");
@@ -102,10 +102,10 @@ Result<bool> AssetCache::loadAsset(const Path &path, bool updateExisting) {
   }
 
   // Handle files that are not in liquid format
-  auto meta = getMetaFromUuid(uuid);
+  auto meta = getAssetMeta(uuid);
 
   if (meta.type == AssetType::Texture) {
-    auto res = loadTextureFromFile(path);
+    auto res = loadTexture(uuid);
     if (res.hasError()) {
       return Result<bool>::Error(res.getError());
     }
@@ -114,8 +114,7 @@ Result<bool> AssetCache::loadAsset(const Path &path, bool updateExisting) {
   }
 
   if (meta.type == AssetType::LuaScript) {
-    auto res =
-        loadLuaScriptFromFile(path, static_cast<LuaScriptAssetHandle>(handle));
+    auto res = loadLuaScript(uuid, static_cast<LuaScriptAssetHandle>(handle));
     if (res.hasError()) {
       return Result<bool>::Error(res.getError());
     }
@@ -124,8 +123,7 @@ Result<bool> AssetCache::loadAsset(const Path &path, bool updateExisting) {
   }
 
   if (meta.type == AssetType::Animator) {
-    auto res =
-        loadAnimatorFromFile(path, static_cast<AnimatorAssetHandle>(handle));
+    auto res = loadAnimator(uuid, static_cast<AnimatorAssetHandle>(handle));
     if (res.hasError()) {
       return Result<bool>::Error(res.getError());
     }
@@ -134,7 +132,7 @@ Result<bool> AssetCache::loadAsset(const Path &path, bool updateExisting) {
   }
 
   if (meta.type == AssetType::Audio) {
-    auto res = loadAudioFromFile(path);
+    auto res = loadAudio(uuid);
     if (res.hasError()) {
       return Result<bool>::Error(res.getError());
     }
@@ -143,7 +141,7 @@ Result<bool> AssetCache::loadAsset(const Path &path, bool updateExisting) {
   }
 
   if (meta.type == AssetType::Font) {
-    auto res = loadFontFromFile(path);
+    auto res = loadFont(uuid);
     if (res.hasError()) {
       return Result<bool>::Error(res.getError());
     }
@@ -152,7 +150,7 @@ Result<bool> AssetCache::loadAsset(const Path &path, bool updateExisting) {
   }
 
   if (meta.type == AssetType::Scene) {
-    auto res = loadSceneFromFile(path);
+    auto res = loadScene(uuid);
     if (res.hasError()) {
       return Result<bool>::Error(res.getError());
     }
@@ -234,8 +232,8 @@ Result<bool> AssetCache::loadAsset(const Path &path, bool updateExisting) {
   return Result<bool>::Error("Unknown asset file: " + path.stem().string());
 }
 
-Result<Path> AssetCache::createMetaFile(AssetType type, String name,
-                                        Path path) {
+Result<Path> AssetCache::createAssetMeta(AssetType type, String name,
+                                         Path path) {
   auto metaPath = path.replace_extension("assetmeta");
   OutputBinaryStream stream(path);
 
@@ -248,13 +246,6 @@ Result<Path> AssetCache::createMetaFile(AssetType type, String name,
   stream.write(name);
 
   return Result<Path>::Ok(metaPath);
-}
-
-Path AssetCache::createAssetPath(const Uuid &uuid) {
-  auto stem = uuid.isEmpty() ? Uuid::generate() : uuid;
-  return (mAssetsPath / stem.toString())
-      .replace_extension("asset")
-      .make_preferred();
 }
 
 Path AssetCache::getPathFromUuid(const Uuid &uuid) {

--- a/engine/src/liquid/asset/AssetCache.h
+++ b/engine/src/liquid/asset/AssetCache.h
@@ -50,10 +50,10 @@ public:
   /**
    * @brief Load texture from file
    *
-   * @param filePath Path to asset
+   * @param uuid Texture uuid
    * @return Texture asset handle
    */
-  Result<TextureAssetHandle> loadTextureFromFile(const Path &filePath);
+  Result<TextureAssetHandle> loadTexture(const Uuid &uuid);
 
   /**
    * @brief Create font from source
@@ -67,10 +67,10 @@ public:
   /**
    * @brief Load font from file
    *
-   * @param filePath Path to asset
+   * @param uuid Font uuid
    * @return Font asset handle
    */
-  Result<FontAssetHandle> loadFontFromFile(const Path &filePath);
+  Result<FontAssetHandle> loadFont(const Uuid &uuid);
 
   /**
    * @brief Create material from asset
@@ -86,10 +86,10 @@ public:
   /**
    * @brief Load material from file
    *
-   * @param filePath Path to asset
+   * @param uuid Material uuid
    * @return Material asset handle
    */
-  Result<MaterialAssetHandle> loadMaterialFromFile(const Path &filePath);
+  Result<MaterialAssetHandle> loadMaterial(const Uuid &uuid);
 
   /**
    * @brief Create mesh from asset
@@ -105,10 +105,10 @@ public:
   /**
    * @brief Load mesh from file
    *
-   * @param filePath Path to asset
+   * @param uuid Mesh uuid
    * @return Mesh asset handle
    */
-  Result<MeshAssetHandle> loadMeshFromFile(const Path &filePath);
+  Result<MeshAssetHandle> loadMesh(const Uuid &uuid);
 
   /**
    * @brief Create skeleton from asset
@@ -122,12 +122,12 @@ public:
   Result<Path> createSkeletonFromAsset(const AssetData<SkeletonAsset> &asset);
 
   /**
-   * @brief Load skeleton from file
+   * @brief Load skeleton
    *
-   * @param filePath Path to asset
+   * @param uuid Skeleton uuid
    * @return Skeleton asset handle
    */
-  Result<SkeletonAssetHandle> loadSkeletonFromFile(const Path &filePath);
+  Result<SkeletonAssetHandle> loadSkeleton(const Uuid &uuid);
 
   /**
    * @brief Create animation from asset
@@ -141,12 +141,12 @@ public:
   Result<Path> createAnimationFromAsset(const AssetData<AnimationAsset> &asset);
 
   /**
-   * @brief Load animation from file
+   * @brief Load animation
    *
-   * @param filePath Path to asset
+   * @param uuid Animation uuid
    * @return Animation asset handle
    */
-  Result<AnimationAssetHandle> loadAnimationFromFile(const Path &filePath);
+  Result<AnimationAssetHandle> loadAnimation(const Uuid &uuid);
 
   /**
    * @brief Create animator from source
@@ -170,15 +170,15 @@ public:
   Result<Path> createAnimatorFromAsset(const AssetData<AnimatorAsset> &asset);
 
   /**
-   * @brief Load animator from file
+   * @brief Load animator
    *
-   * @param filePath Path to asset
+   * @param uuid Animator uuid
    * @param handle Existing asset handle
    * @return Animator asset handle
    */
   Result<AnimatorAssetHandle>
-  loadAnimatorFromFile(const Path &filePath,
-                       AnimatorAssetHandle handle = AnimatorAssetHandle::Null);
+  loadAnimator(const Uuid &uuid,
+               AnimatorAssetHandle handle = AnimatorAssetHandle::Null);
 
   /**
    * @brief Copy audio from source
@@ -190,12 +190,12 @@ public:
   Result<Path> createAudioFromSource(const Path &sourcePath, const Uuid &uuid);
 
   /**
-   * @brief Load audio from file
+   * @brief Load audio
    *
-   * @param filePath Path to asset
+   * @param uuid Audio uuid
    * @return Audio asset handle
    */
-  Result<AudioAssetHandle> loadAudioFromFile(const Path &filePath);
+  Result<AudioAssetHandle> loadAudio(const Uuid &uuid);
 
   /**
    * @brief Create prefab from asset
@@ -209,12 +209,12 @@ public:
   Result<Path> createPrefabFromAsset(const AssetData<PrefabAsset> &asset);
 
   /**
-   * @brief Load prefab from file
+   * @brief Load prefab
    *
-   * @param filePath Path to asset
+   * @param uuid Prefab uuid
    * @return Prefab asset handle
    */
-  Result<PrefabAssetHandle> loadPrefabFromFile(const Path &filePath);
+  Result<PrefabAssetHandle> loadPrefab(const Uuid &uuid);
 
   /**
    * @brief Create environment from asset
@@ -231,10 +231,10 @@ public:
   /**
    * @brief Load environment from file
    *
-   * @param filePath Path to asset
+   * @param uuid Environment uuid
    * @return Environment asset handle
    */
-  Result<EnvironmentAssetHandle> loadEnvironmentFromFile(const Path &filePath);
+  Result<EnvironmentAssetHandle> loadEnvironment(const Uuid &uuid);
 
   /**
    * @brief Create Lua script from source
@@ -247,15 +247,15 @@ public:
                                          const Uuid &uuid);
 
   /**
-   * @brief Load Lua script from file
+   * @brief Load Lua script
    *
-   * @param filePath Path to asset
+   * @param uuid Lua script uuid
    * @param handle Lua script handle
    * @return Lua script handle
    */
-  Result<LuaScriptAssetHandle> loadLuaScriptFromFile(
-      const Path &filePath,
-      LuaScriptAssetHandle handle = LuaScriptAssetHandle::Null);
+  Result<LuaScriptAssetHandle>
+  loadLuaScript(const Uuid &uuid,
+                LuaScriptAssetHandle handle = LuaScriptAssetHandle::Null);
 
   /**
    * @brief Create scene from source
@@ -267,12 +267,12 @@ public:
   Result<Path> createSceneFromSource(const Path &sourcePath, const Uuid &uuid);
 
   /**
-   * @brief Load scene from file
+   * @brief Load scene
    *
-   * @param filePath Path to asset
+   * @param uuid Scene uuid
    * @return Scene asset handle
    */
-  Result<SceneAssetHandle> loadSceneFromFile(const Path &filePath);
+  Result<SceneAssetHandle> loadScene(const Uuid &uuid);
 
   /**
    * @brief Get asset registry
@@ -313,20 +313,15 @@ public:
    * @param uuid Asset uuid
    * @return Asset meta
    */
-  AssetMeta getMetaFromUuid(const Uuid &uuid) const;
+  AssetMeta getAssetMeta(const Uuid &uuid) const;
 
   /**
-   * @brief Create asset metafile
+   * @brief Get asset path from uuid
    *
-   * Creates file in the same path as
-   * the path of the asset
-   *
-   * @param type Asset type
-   * @param name Asset name
-   * @param path Full path to asset
-   * @return Path to meta file
+   * @param uuid Asset uuid
+   * @return Path to asset
    */
-  Result<Path> createMetaFile(AssetType type, String name, Path path);
+  Path getPathFromUuid(const Uuid &uuid);
 
 private:
   /**
@@ -358,6 +353,19 @@ private:
   Result<AssetFileHeader> checkAssetFile(InputBinaryStream &file,
                                          const Path &filePath,
                                          AssetType assetType);
+
+  /**
+   * @brief Create asset metafile
+   *
+   * Creates file in the same path as
+   * the path of the asset
+   *
+   * @param type Asset type
+   * @param name Asset name
+   * @param path Full path to asset
+   * @return Path to meta file
+   */
+  Result<Path> createAssetMeta(AssetType type, String name, Path path);
 
   /**
    * @brief Load single asset
@@ -449,69 +457,52 @@ private:
 
 private:
   /**
-   * @brief Get asset path from uuid
-   *
-   * @param uuid Asset uuid
-   * @return Path to asset
-   */
-  Path getPathFromUuid(const Uuid &uuid);
-
-  /**
-   * @brief Get or load texture from uuid
+   * @brief Get or load texture
    *
    * @param uuid Asset uuid
    * @return Existing or newly loaded texture
    */
-  Result<TextureAssetHandle> getOrLoadTextureFromUuid(const Uuid &uuid);
+  Result<TextureAssetHandle> getOrLoadTexture(const Uuid &uuid);
 
   /**
-   * @brief Get or load material from uuid
+   * @brief Get or load material
    *
-   * @param uuid Asset uuid
+   * @param uuid Material uuid
    * @return Existing or newly loaded material
    */
-  Result<MaterialAssetHandle> getOrLoadMaterialFromUuid(const Uuid &uuid);
+  Result<MaterialAssetHandle> getOrLoadMaterial(const Uuid &uuid);
 
   /**
-   * @brief Get or load mesh from uuid
+   * @brief Get or load mesh
    *
-   * @param uuid Asset uuid
+   * @param uuid Mesh uuid
    * @return Existing or newly loaded mesh
    */
-  Result<MeshAssetHandle> getOrLoadMeshFromUuid(const Uuid &uuid);
+  Result<MeshAssetHandle> getOrLoadMesh(const Uuid &uuid);
 
   /**
-   * @brief Get or load skeleton from uuid
+   * @brief Get or load skeleton
    *
-   * @param uuid Asset uuid
+   * @param uuid Skeleton uuid
    * @return Existing or newly loaded skeleton
    */
-  Result<SkeletonAssetHandle> getOrLoadSkeletonFromUuid(const Uuid &uuid);
+  Result<SkeletonAssetHandle> getOrLoadSkeleton(const Uuid &uuid);
 
   /**
-   * @brief Get or load animation from uuid
+   * @brief Get or load animation
    *
-   * @param uuid Asset uuid
+   * @param uuid Animation uuid
    * @return Existing or newly loaded animation
    */
-  Result<AnimationAssetHandle> getOrLoadAnimationFromUuid(const Uuid &uuid);
+  Result<AnimationAssetHandle> getOrLoadAnimation(const Uuid &uuid);
 
   /**
-   * @brief Get or load animator from uuid
+   * @brief Get or load aniamtor from uuid
    *
-   * @param uuid Asset uuid
+   * @param uuid Animator uuid
    * @return Existing or newly loaded animator
    */
-  Result<AnimatorAssetHandle> getOrLoadAnimatorFromUuid(const Uuid &uuid);
-
-private:
-  /**
-   * @brief Create asset path
-   *
-   * @param uuid Asset uuid
-   * @return Asset path
-   */
-  Path createAssetPath(const Uuid &uuid);
+  Result<AnimatorAssetHandle> getOrLoadAnimator(const Uuid &uuid);
 
 private:
   AssetRegistry mRegistry;

--- a/engine/src/liquid/asset/AssetCacheAnimation.cpp
+++ b/engine/src/liquid/asset/AssetCacheAnimation.cpp
@@ -11,7 +11,12 @@ namespace liquid {
 
 Result<Path>
 AssetCache::createAnimationFromAsset(const AssetData<AnimationAsset> &asset) {
-  auto assetPath = createAssetPath(asset.uuid);
+  if (asset.uuid.isEmpty()) {
+    LIQUID_ASSERT(false, "Invalid uuid provided");
+    return Result<Path>::Error("Invalid uuid provided");
+  }
+
+  auto assetPath = getPathFromUuid(asset.uuid);
 
   OutputBinaryStream file(assetPath);
 
@@ -79,8 +84,9 @@ AssetCache::loadAnimationDataFromInputStream(InputBinaryStream &stream,
       mRegistry.getAnimations().addAsset(animation));
 }
 
-Result<AnimationAssetHandle>
-AssetCache::loadAnimationFromFile(const Path &filePath) {
+Result<AnimationAssetHandle> AssetCache::loadAnimation(const Uuid &uuid) {
+  auto filePath = getPathFromUuid(uuid);
+
   InputBinaryStream stream(filePath);
 
   const auto &header = checkAssetFile(stream, filePath, AssetType::Animation);
@@ -91,8 +97,7 @@ AssetCache::loadAnimationFromFile(const Path &filePath) {
   return loadAnimationDataFromInputStream(stream, filePath, header.getData());
 }
 
-Result<AnimationAssetHandle>
-AssetCache::getOrLoadAnimationFromUuid(const Uuid &uuid) {
+Result<AnimationAssetHandle> AssetCache::getOrLoadAnimation(const Uuid &uuid) {
   if (uuid.isEmpty()) {
     return Result<AnimationAssetHandle>::Ok(AnimationAssetHandle::Null);
   }
@@ -102,7 +107,7 @@ AssetCache::getOrLoadAnimationFromUuid(const Uuid &uuid) {
     return Result<AnimationAssetHandle>::Ok(handle);
   }
 
-  return loadAnimationFromFile(getPathFromUuid(uuid));
+  return loadAnimation(uuid);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/asset/AssetCacheMaterial.cpp
+++ b/engine/src/liquid/asset/AssetCacheMaterial.cpp
@@ -11,7 +11,12 @@ namespace liquid {
 
 Result<Path>
 AssetCache::createMaterialFromAsset(const AssetData<MaterialAsset> &asset) {
-  auto assetPath = createAssetPath(asset.uuid);
+  if (asset.uuid.isEmpty()) {
+    LIQUID_ASSERT(false, "Invalid uuid provided");
+    return Result<Path>::Error("Invalid uuid provided");
+  }
+
+  auto assetPath = getPathFromUuid(asset.uuid);
 
   OutputBinaryStream file(assetPath);
 
@@ -76,7 +81,7 @@ AssetCache::loadMaterialDataFromInputStream(InputBinaryStream &stream,
   {
     Uuid textureUuid;
     stream.read(textureUuid);
-    const auto &res = getOrLoadTextureFromUuid(textureUuid);
+    const auto &res = getOrLoadTexture(textureUuid);
     if (res.hasData()) {
       material.data.baseColorTexture = res.getData();
       warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -92,7 +97,7 @@ AssetCache::loadMaterialDataFromInputStream(InputBinaryStream &stream,
   {
     Uuid textureUuid;
     stream.read(textureUuid);
-    const auto &res = getOrLoadTextureFromUuid(textureUuid);
+    const auto &res = getOrLoadTexture(textureUuid);
     if (res.hasData()) {
       material.data.metallicRoughnessTexture = res.getData();
       warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -110,7 +115,7 @@ AssetCache::loadMaterialDataFromInputStream(InputBinaryStream &stream,
   {
     Uuid textureUuid;
     stream.read(textureUuid);
-    const auto &res = getOrLoadTextureFromUuid(textureUuid);
+    const auto &res = getOrLoadTexture(textureUuid);
     if (res.hasData()) {
       material.data.normalTexture = res.getData();
       warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -126,7 +131,7 @@ AssetCache::loadMaterialDataFromInputStream(InputBinaryStream &stream,
   {
     Uuid textureUuid;
     stream.read(textureUuid);
-    const auto &res = getOrLoadTextureFromUuid(textureUuid);
+    const auto &res = getOrLoadTexture(textureUuid);
     if (res.hasData()) {
       material.data.occlusionTexture = res.getData();
       warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -142,7 +147,7 @@ AssetCache::loadMaterialDataFromInputStream(InputBinaryStream &stream,
   {
     Uuid textureUuid;
     stream.read(textureUuid);
-    const auto &res = getOrLoadTextureFromUuid(textureUuid);
+    const auto &res = getOrLoadTexture(textureUuid);
     if (res.hasData()) {
       material.data.emissiveTexture = res.getData();
       warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -158,8 +163,8 @@ AssetCache::loadMaterialDataFromInputStream(InputBinaryStream &stream,
       mRegistry.getMaterials().addAsset(material), warnings);
 }
 
-Result<MaterialAssetHandle>
-AssetCache::loadMaterialFromFile(const Path &filePath) {
+Result<MaterialAssetHandle> AssetCache::loadMaterial(const Uuid &uuid) {
+  auto filePath = getPathFromUuid(uuid);
   InputBinaryStream stream(filePath);
 
   if (!stream.good()) {
@@ -175,8 +180,7 @@ AssetCache::loadMaterialFromFile(const Path &filePath) {
   return loadMaterialDataFromInputStream(stream, filePath, header.getData());
 }
 
-Result<MaterialAssetHandle>
-AssetCache::getOrLoadMaterialFromUuid(const Uuid &uuid) {
+Result<MaterialAssetHandle> AssetCache::getOrLoadMaterial(const Uuid &uuid) {
   if (uuid.isEmpty()) {
     return Result<MaterialAssetHandle>::Ok(MaterialAssetHandle::Null);
   }
@@ -186,7 +190,7 @@ AssetCache::getOrLoadMaterialFromUuid(const Uuid &uuid) {
     return Result<MaterialAssetHandle>::Ok(handle);
   }
 
-  return loadMaterialFromFile(getPathFromUuid(uuid));
+  return loadMaterial(uuid);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/asset/AssetCacheMesh.cpp
+++ b/engine/src/liquid/asset/AssetCacheMesh.cpp
@@ -11,7 +11,12 @@ namespace liquid {
 
 Result<Path>
 AssetCache::createMeshFromAsset(const AssetData<MeshAsset> &asset) {
-  auto assetPath = createAssetPath(asset.uuid);
+  if (asset.uuid.isEmpty()) {
+    LIQUID_ASSERT(false, "Invalid uuid provided");
+    return Result<Path>::Error("Invalid uuid provided");
+  }
+
+  auto assetPath = getPathFromUuid(asset.uuid);
 
   OutputBinaryStream file(assetPath);
 
@@ -112,7 +117,9 @@ AssetCache::loadMeshDataFromInputStream(InputBinaryStream &stream,
                                      warnings);
 }
 
-Result<MeshAssetHandle> AssetCache::loadMeshFromFile(const Path &filePath) {
+Result<MeshAssetHandle> AssetCache::loadMesh(const Uuid &uuid) {
+  auto filePath = getPathFromUuid(uuid);
+
   InputBinaryStream stream(filePath);
 
   const auto &header = checkAssetFile(stream, filePath, AssetType::None);
@@ -129,7 +136,7 @@ Result<MeshAssetHandle> AssetCache::loadMeshFromFile(const Path &filePath) {
   return loadMeshDataFromInputStream(stream, filePath, header.getData());
 }
 
-Result<MeshAssetHandle> AssetCache::getOrLoadMeshFromUuid(const Uuid &uuid) {
+Result<MeshAssetHandle> AssetCache::getOrLoadMesh(const Uuid &uuid) {
   if (uuid.isEmpty()) {
     return Result<MeshAssetHandle>::Ok(MeshAssetHandle::Null);
   }
@@ -139,7 +146,7 @@ Result<MeshAssetHandle> AssetCache::getOrLoadMeshFromUuid(const Uuid &uuid) {
     return Result<MeshAssetHandle>::Ok(handle);
   }
 
-  return loadMeshFromFile(getPathFromUuid(uuid));
+  return loadMesh(uuid);
 }
 
 } // namespace liquid

--- a/engine/src/liquid/asset/AssetCachePrefab.cpp
+++ b/engine/src/liquid/asset/AssetCachePrefab.cpp
@@ -11,7 +11,12 @@ namespace liquid {
 
 Result<Path>
 AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
-  auto assetPath = createAssetPath(asset.uuid);
+  if (asset.uuid.isEmpty()) {
+    LIQUID_ASSERT(false, "Invalid uuid provided");
+    return Result<Path>::Error("Invalid uuid provided");
+  }
+
+  auto assetPath = getPathFromUuid(asset.uuid);
 
   OutputBinaryStream file(assetPath);
 
@@ -272,7 +277,7 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
 
     for (uint32_t i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
-      const auto &res = getOrLoadMaterialFromUuid(assetUuid);
+      const auto &res = getOrLoadMaterial(assetUuid);
       if (res.hasData()) {
         localMaterialMap.at(i) = res.getData();
         warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -293,7 +298,7 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
 
     for (uint32_t i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
-      const auto &res = getOrLoadMeshFromUuid(assetUuid);
+      const auto &res = getOrLoadMesh(assetUuid);
       if (res.hasData()) {
         localMeshMap.at(i) = res.getData();
         warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -314,7 +319,7 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
 
     for (uint32_t i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
-      const auto &res = getOrLoadSkeletonFromUuid(assetUuid);
+      const auto &res = getOrLoadSkeleton(assetUuid);
       if (res.hasData()) {
         localSkeletonMap.at(i) = res.getData();
         warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -337,7 +342,7 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
 
     for (uint32_t i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
-      const auto &res = getOrLoadAnimationFromUuid(assetUuid);
+      const auto &res = getOrLoadAnimation(assetUuid);
       if (res.hasData()) {
         localAnimationMap.at(i) = res.getData();
         warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -361,7 +366,7 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
 
     for (uint32_t i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
-      const auto &res = getOrLoadAnimatorFromUuid(assetUuid);
+      const auto &res = getOrLoadAnimator(assetUuid);
       if (res.hasData()) {
         localAnimatorMap.at(i) = res.getData();
         warnings.insert(warnings.end(), res.getWarnings().begin(),
@@ -579,7 +584,9 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
                                        warnings);
 }
 
-Result<PrefabAssetHandle> AssetCache::loadPrefabFromFile(const Path &filePath) {
+Result<PrefabAssetHandle> AssetCache::loadPrefab(const Uuid &uuid) {
+  auto filePath = getPathFromUuid(uuid);
+
   InputBinaryStream stream(filePath);
 
   const auto &header = checkAssetFile(stream, filePath, AssetType::Prefab);

--- a/engine/src/liquid/asset/AssetCacheSkeleton.cpp
+++ b/engine/src/liquid/asset/AssetCacheSkeleton.cpp
@@ -11,7 +11,12 @@ namespace liquid {
 
 Result<Path>
 AssetCache::createSkeletonFromAsset(const AssetData<SkeletonAsset> &asset) {
-  auto assetPath = createAssetPath(asset.uuid);
+  if (asset.uuid.isEmpty()) {
+    LIQUID_ASSERT(false, "Invalid uuid provided");
+    return Result<Path>::Error("Invalid uuid provided");
+  }
+
+  auto assetPath = getPathFromUuid(asset.uuid);
 
   OutputBinaryStream file(assetPath);
 
@@ -70,8 +75,8 @@ AssetCache::loadSkeletonDataFromInputStream(InputBinaryStream &stream,
       mRegistry.getSkeletons().addAsset(skeleton));
 }
 
-Result<SkeletonAssetHandle>
-AssetCache::loadSkeletonFromFile(const Path &filePath) {
+Result<SkeletonAssetHandle> AssetCache::loadSkeleton(const Uuid &uuid) {
+  auto filePath = getPathFromUuid(uuid);
   InputBinaryStream stream(filePath);
 
   const auto &header = checkAssetFile(stream, filePath, AssetType::Skeleton);
@@ -82,8 +87,7 @@ AssetCache::loadSkeletonFromFile(const Path &filePath) {
   return loadSkeletonDataFromInputStream(stream, filePath, header.getData());
 }
 
-Result<SkeletonAssetHandle>
-AssetCache::getOrLoadSkeletonFromUuid(const Uuid &uuid) {
+Result<SkeletonAssetHandle> AssetCache::getOrLoadSkeleton(const Uuid &uuid) {
   if (uuid.isEmpty()) {
     return Result<SkeletonAssetHandle>::Ok(SkeletonAssetHandle::Null);
   }
@@ -93,7 +97,7 @@ AssetCache::getOrLoadSkeletonFromUuid(const Uuid &uuid) {
     return Result<SkeletonAssetHandle>::Ok(handle);
   }
 
-  return loadSkeletonFromFile(getPathFromUuid(uuid));
+  return loadSkeleton(uuid);
 }
 
 } // namespace liquid

--- a/engine/tests/liquid-tests/asset/AssetCacheAnimation.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheAnimation.test.cpp
@@ -16,6 +16,7 @@ public:
 liquid::AssetData<liquid::AnimationAsset> createRandomizedAnimation() {
   liquid::AssetData<liquid::AnimationAsset> asset;
   asset.name = "test-anim0";
+  asset.uuid = liquid::Uuid::generate();
   {
     std::random_device device;
     std::mt19937 mt(device());
@@ -114,7 +115,7 @@ TEST_F(AssetCacheAnimationTest, LoadsAnimationAssetFromFile) {
   auto asset = createRandomizedAnimation();
 
   auto filePath = cache.createAnimationFromAsset(asset);
-  auto handle = cache.loadAnimationFromFile(filePath.getData());
+  auto handle = cache.loadAnimation(asset.uuid);
   EXPECT_FALSE(handle.hasError());
   EXPECT_NE(handle.getData(), liquid::AnimationAssetHandle::Null);
 

--- a/engine/tests/liquid-tests/asset/AssetCacheAudioTest.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheAudioTest.test.cpp
@@ -11,26 +11,27 @@ public:
 TEST_F(AssetCacheAudioTest, CreatesAudioFromSource) {
   auto audioPath = FixturesPath / "valid-audio.wav";
 
-  auto filePath =
-      cache.createAudioFromSource(audioPath, liquid::Uuid::generate());
+  auto uuid = liquid::Uuid::generate();
+
+  auto filePath = cache.createAudioFromSource(audioPath, uuid);
   EXPECT_TRUE(filePath.hasData());
   EXPECT_FALSE(filePath.hasError());
   EXPECT_FALSE(filePath.hasWarnings());
 
   EXPECT_EQ(filePath.getData().filename().string().size(), 38);
 
-  auto meta =
-      cache.getMetaFromUuid(liquid::Uuid(filePath.getData().stem().string()));
+  auto meta = cache.getAssetMeta(uuid);
   EXPECT_EQ(meta.type, liquid::AssetType::Audio);
   EXPECT_EQ(meta.name, "valid-audio.wav");
 }
 
 TEST_F(AssetCacheAudioTest, LoadsWavAudioFileIntoRegistry) {
   auto audioPath = FixturesPath / "valid-audio.wav";
-  auto filePath =
-      cache.createAudioFromSource(audioPath, liquid::Uuid::generate());
 
-  auto result = cache.loadAudioFromFile(filePath.getData());
+  auto uuid = liquid::Uuid::generate();
+
+  auto filePath = cache.createAudioFromSource(audioPath, uuid);
+  auto result = cache.loadAudio(uuid);
 
   EXPECT_TRUE(result.hasData());
   EXPECT_FALSE(result.hasError());
@@ -47,9 +48,9 @@ TEST_F(AssetCacheAudioTest, LoadsWavAudioFileIntoRegistry) {
 }
 
 TEST_F(AssetCacheAudioTest, FileReturnsErrorIfAudioFileCannotBeOpened) {
-  auto filePath = CachePath / "non-existent-file.wav";
+  auto uuid = liquid::Uuid::generate();
 
-  auto result = cache.loadAudioFromFile(filePath);
+  auto result = cache.loadAudio(uuid);
   EXPECT_TRUE(result.hasError());
   EXPECT_FALSE(result.hasWarnings());
   EXPECT_FALSE(result.hasData());

--- a/engine/tests/liquid-tests/asset/AssetCacheFont.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheFont.test.cpp
@@ -9,9 +9,9 @@ public:
 };
 
 TEST_F(AssetCacheFontTest, CreatesFontFromSource) {
+  auto uuid = liquid::Uuid::generate();
   auto sourcePath = FixturesPath / "valid-font.ttf";
-  auto filePath =
-      cache.createFontFromSource(sourcePath, liquid::Uuid::generate());
+  auto filePath = cache.createFontFromSource(sourcePath, uuid);
 
   EXPECT_TRUE(filePath.hasData());
   EXPECT_FALSE(filePath.hasError());
@@ -19,8 +19,7 @@ TEST_F(AssetCacheFontTest, CreatesFontFromSource) {
 
   EXPECT_EQ(filePath.getData().filename().string().size(), 38);
 
-  auto meta =
-      cache.getMetaFromUuid(liquid::Uuid(filePath.getData().stem().string()));
+  auto meta = cache.getAssetMeta(uuid);
 
   EXPECT_EQ(meta.type, liquid::AssetType::Font);
   EXPECT_EQ(meta.name, "valid-font.ttf");
@@ -28,10 +27,10 @@ TEST_F(AssetCacheFontTest, CreatesFontFromSource) {
 
 TEST_F(AssetCacheFontTest, LoadsTTFFontFromFile) {
   auto sourcePath = FixturesPath / "valid-font.ttf";
-  auto filePath =
-      cache.createFontFromSource(sourcePath, liquid::Uuid::generate());
+  auto uuid = liquid::Uuid::generate();
+  auto filePath = cache.createFontFromSource(sourcePath, uuid);
 
-  auto result = cache.loadFontFromFile(filePath.getData());
+  auto result = cache.loadFont(uuid);
 
   EXPECT_TRUE(result.hasData());
   EXPECT_FALSE(result.hasError());
@@ -48,10 +47,10 @@ TEST_F(AssetCacheFontTest, LoadsTTFFontFromFile) {
 
 TEST_F(AssetCacheFontTest, LoadsOTFFontFromFile) {
   auto sourcePath = FixturesPath / "valid-font.otf";
-  auto filePath =
-      cache.createFontFromSource(sourcePath, liquid::Uuid::generate());
+  auto uuid = liquid::Uuid::generate();
+  auto filePath = cache.createFontFromSource(sourcePath, uuid);
 
-  auto result = cache.loadFontFromFile(filePath.getData());
+  auto result = cache.loadFont(uuid);
 
   EXPECT_TRUE(result.hasData());
   EXPECT_FALSE(result.hasError());
@@ -66,10 +65,8 @@ TEST_F(AssetCacheFontTest, LoadsOTFFontFromFile) {
   EXPECT_EQ(asset.name, "valid-font.otf");
 }
 
-TEST_F(AssetCacheFontTest, FileReturnsErrorIfAudioFileCannotBeOpened) {
-  auto filePath = CachePath / "non-existent-file.asset";
-
-  auto result = cache.loadFontFromFile(filePath);
+TEST_F(AssetCacheFontTest, FileReturnsErrorIfFontFileCannotBeOpened) {
+  auto result = cache.loadFont(liquid::Uuid::generate());
   EXPECT_TRUE(result.hasError());
   EXPECT_FALSE(result.hasWarnings());
   EXPECT_FALSE(result.hasData());

--- a/engine/tests/liquid-tests/asset/AssetCacheMesh.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheMesh.test.cpp
@@ -14,6 +14,7 @@ public:
   liquid::AssetData<liquid::MeshAsset> createRandomizedMeshAsset() {
     liquid::AssetData<liquid::MeshAsset> asset;
     asset.name = "test-mesh0";
+    asset.uuid = liquid::Uuid::generate();
     asset.type = liquid::AssetType::Mesh;
 
     {
@@ -49,6 +50,7 @@ public:
   liquid::AssetData<liquid::MeshAsset> createRandomizedSkinnedMeshAsset() {
     liquid::AssetData<liquid::MeshAsset> asset;
     asset.name = "test-mesh0";
+    asset.uuid = liquid::Uuid::generate();
     asset.type = liquid::AssetType::SkinnedMesh;
 
     std::random_device device;
@@ -171,7 +173,7 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadMeshIfItHasNoVertices) {
   }
 
   auto filePath = cache.createMeshFromAsset(asset).getData();
-  auto handle = cache.loadMeshFromFile(filePath);
+  auto handle = cache.loadMesh(asset.uuid);
   EXPECT_TRUE(handle.hasError());
 }
 
@@ -182,14 +184,14 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadMeshIfItHasNoIndices) {
   }
 
   auto filePath = cache.createMeshFromAsset(asset).getData();
-  auto handle = cache.loadMeshFromFile(filePath);
+  auto handle = cache.loadMesh(asset.uuid);
   EXPECT_TRUE(handle.hasError());
 }
 
 TEST_F(AssetCacheMeshTest, LoadsMeshFromFile) {
   auto asset = createRandomizedMeshAsset();
   auto filePath = cache.createMeshFromAsset(asset).getData();
-  auto handleRes = cache.loadMeshFromFile(filePath);
+  auto handleRes = cache.loadMesh(asset.uuid);
 
   auto handle = handleRes.getData();
   EXPECT_NE(handle, liquid::MeshAssetHandle::Null);
@@ -321,7 +323,7 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadSkinnedMeshIfItHasNoVertices) {
   }
 
   auto filePath = cache.createMeshFromAsset(asset).getData();
-  auto handle = cache.loadMeshFromFile(filePath);
+  auto handle = cache.loadMesh(asset.uuid);
   EXPECT_TRUE(handle.hasError());
 }
 
@@ -332,7 +334,7 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadSkinnedMeshIfItHasNoIndices) {
   }
 
   auto filePath = cache.createMeshFromAsset(asset).getData();
-  auto handle = cache.loadMeshFromFile(filePath);
+  auto handle = cache.loadMesh(asset.uuid);
   EXPECT_TRUE(handle.hasError());
 }
 
@@ -340,7 +342,7 @@ TEST_F(AssetCacheMeshTest, LoadsSkinnedMeshFromFile) {
   auto asset = createRandomizedSkinnedMeshAsset();
 
   auto filePath = cache.createMeshFromAsset(asset);
-  auto handle = cache.loadMeshFromFile(filePath.getData());
+  auto handle = cache.loadMesh(asset.uuid);
   EXPECT_NE(handle.getData(), liquid::MeshAssetHandle::Null);
   auto &mesh = cache.getRegistry().getMeshes().getAsset(handle.getData());
   EXPECT_EQ(mesh.name, asset.name);

--- a/engine/tests/liquid-tests/asset/AssetCacheScene.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheScene.test.cpp
@@ -12,16 +12,16 @@ public:
 };
 
 TEST_F(AssetCacheSceneTest, CreatesSceneFromSource) {
-  auto filePath = cache.createSceneFromSource(FixturesPath / "test.scene",
-                                              liquid::Uuid::generate());
+  auto uuid = liquid::Uuid::generate();
+  auto filePath =
+      cache.createSceneFromSource(FixturesPath / "test.scene", uuid);
   EXPECT_TRUE(filePath.hasData());
   EXPECT_FALSE(filePath.hasError());
   EXPECT_FALSE(filePath.hasWarnings());
 
   EXPECT_EQ(filePath.getData().filename().string().size(), 38);
 
-  auto meta =
-      cache.getMetaFromUuid(liquid::Uuid(filePath.getData().stem().string()));
+  auto meta = cache.getAssetMeta(uuid);
 
   EXPECT_EQ(meta.type, liquid::AssetType::Scene);
   EXPECT_EQ(meta.name, "test.scene");
@@ -35,11 +35,13 @@ TEST_F(AssetCacheSceneTest, LoadSceneFailsIfTypeIsInvalid) {
   node["zones"] = YAML::Node(YAML::NodeType::Sequence);
   node["entities"] = YAML::Node(YAML::NodeType::Sequence);
 
-  std::ofstream stream(CachePath / "test.asset");
+  auto uuid = liquid::Uuid::generate();
+
+  std::ofstream stream(cache.getPathFromUuid(uuid));
   stream << node;
   stream.close();
 
-  auto res = cache.loadSceneFromFile(CachePath / "test.asset");
+  auto res = cache.loadScene(uuid);
   EXPECT_FALSE(res.hasData());
   EXPECT_TRUE(res.hasError());
   EXPECT_FALSE(res.hasWarnings());
@@ -53,11 +55,14 @@ TEST_F(AssetCacheSceneTest, LoadSceneFailsIfVersionIsInvalid) {
   node["zones"] = YAML::Node(YAML::NodeType::Sequence);
   node["entities"] = YAML::Node(YAML::NodeType::Sequence);
 
-  std::ofstream stream(CachePath / "test.asset");
+  auto uuid = liquid::Uuid::generate();
+
+  std::ofstream stream(cache.getPathFromUuid(uuid));
+
   stream << node;
   stream.close();
 
-  auto res = cache.loadSceneFromFile(CachePath / "test.asset");
+  auto res = cache.loadScene(uuid);
   EXPECT_FALSE(res.hasData());
   EXPECT_TRUE(res.hasError());
   EXPECT_FALSE(res.hasWarnings());
@@ -78,11 +83,14 @@ TEST_F(AssetCacheSceneTest, LoadSceneFailsIfZonesFieldIsNotSequence) {
     node["entities"] = YAML::Node(YAML::NodeType::Sequence);
     node["zones"] = invNode;
 
-    std::ofstream stream(CachePath / "test.asset");
+    auto uuid = liquid::Uuid::generate();
+
+    std::ofstream stream(cache.getPathFromUuid(uuid));
+
     stream << node;
     stream.close();
 
-    auto res = cache.loadSceneFromFile(CachePath / "test.asset");
+    auto res = cache.loadScene(uuid);
     EXPECT_FALSE(res.hasData());
     EXPECT_TRUE(res.hasError());
     EXPECT_FALSE(res.hasWarnings());
@@ -104,11 +112,13 @@ TEST_F(AssetCacheSceneTest, LoadSceneFailsIfEntitiesFieldIsNotSequence) {
     node["zones"] = YAML::Node(YAML::NodeType::Sequence);
     node["entities"] = invNode;
 
-    std::ofstream stream(CachePath / "test.asset");
+    auto uuid = liquid::Uuid::generate();
+
+    std::ofstream stream(cache.getPathFromUuid(uuid));
     stream << node;
     stream.close();
 
-    auto res = cache.loadSceneFromFile(CachePath / "test.asset");
+    auto res = cache.loadScene(uuid);
     EXPECT_FALSE(res.hasData());
     EXPECT_TRUE(res.hasError());
     EXPECT_FALSE(res.hasWarnings());

--- a/engine/tests/liquid-tests/asset/AssetCacheSkeleton.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheSkeleton.test.cpp
@@ -16,6 +16,7 @@ public:
 TEST_F(AssetCacheSkeletonTest, CreatesSkeletonFileFromSkeletonAsset) {
   liquid::AssetData<liquid::SkeletonAsset> asset;
   asset.name = "test-skel0";
+  asset.uuid = liquid::Uuid::generate();
 
   {
     std::random_device device;
@@ -105,6 +106,7 @@ TEST_F(AssetCacheSkeletonTest, CreatesSkeletonFileFromSkeletonAsset) {
 TEST_F(AssetCacheSkeletonTest, LoadsSkeletonAssetFromFile) {
   liquid::AssetData<liquid::SkeletonAsset> asset;
   asset.name = "test-skel0";
+  asset.uuid = liquid::Uuid::generate();
 
   {
     std::random_device device;
@@ -151,7 +153,7 @@ TEST_F(AssetCacheSkeletonTest, LoadsSkeletonAssetFromFile) {
   }
 
   auto filePath = cache.createSkeletonFromAsset(asset);
-  auto handle = cache.loadSkeletonFromFile(filePath.getData());
+  auto handle = cache.loadSkeleton(asset.uuid);
 
   EXPECT_NE(handle.getData(), liquid::SkeletonAssetHandle::Null);
 

--- a/engine/tests/liquid-tests/asset/AssetCacheTexture.test.cpp
+++ b/engine/tests/liquid-tests/asset/AssetCacheTexture.test.cpp
@@ -13,25 +13,26 @@ public:
 };
 
 TEST_F(AssetCacheTextureTest, CreatesTextureFromSource) {
-  auto filePath = cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx",
-                                                liquid::Uuid::generate());
+  auto uuid = liquid::Uuid::generate();
+  auto filePath =
+      cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", uuid);
   EXPECT_TRUE(filePath.hasData());
   EXPECT_FALSE(filePath.hasError());
   EXPECT_FALSE(filePath.hasWarnings());
 
   EXPECT_EQ(filePath.getData().filename().string().size(), 38);
 
-  auto meta =
-      cache.getMetaFromUuid(liquid::Uuid(filePath.getData().stem().string()));
+  auto meta = cache.getAssetMeta(uuid);
 
   EXPECT_EQ(meta.type, liquid::AssetType::Texture);
   EXPECT_EQ(meta.name, "1x1-2d.ktx");
 }
 
 TEST_F(AssetCacheTextureTest, CreatesTextureFromAsset) {
-  auto createdRes = cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx",
-                                                  liquid::Uuid::generate());
-  auto texture = cache.loadTextureFromFile(createdRes.getData());
+  auto uuid = liquid::Uuid::generate();
+  auto createdRes =
+      cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", uuid);
+  auto texture = cache.loadTexture(uuid);
   auto handle = texture.getData();
 
   auto asset = cache.getRegistry().getTextures().getAsset(handle);
@@ -45,17 +46,17 @@ TEST_F(AssetCacheTextureTest, CreatesTextureFromAsset) {
 
   EXPECT_EQ(filePath.getData().filename().string().size(), 38);
 
-  auto meta =
-      cache.getMetaFromUuid(liquid::Uuid(filePath.getData().stem().string()));
+  auto meta = cache.getAssetMeta(uuid);
   EXPECT_EQ(meta.type, liquid::AssetType::Texture);
   EXPECT_EQ(meta.name, "1x1-2d.ktx");
 }
 
 TEST_F(AssetCacheTextureTest, LoadsTextureToRegistry) {
-  auto filePath = cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx",
-                                                liquid::Uuid::generate());
+  auto uuid = liquid::Uuid::generate();
+  auto filePath =
+      cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", uuid);
 
-  auto texture = cache.loadTextureFromFile(filePath.getData());
+  auto texture = cache.loadTexture(uuid);
   auto handle = texture.getData();
 
   auto asset = cache.getRegistry().getTextures().getAsset(handle);
@@ -67,28 +68,30 @@ TEST_F(AssetCacheTextureTest, LoadsTextureToRegistry) {
 
 TEST_F(AssetCacheTextureTest, FailsIfKtxFileCannotBeLoaded) {
   // non-existent file
-  EXPECT_TRUE(cache.loadTextureFromFile(CachePath / "non-existent-file.asset")
-                  .hasError());
+  EXPECT_TRUE(cache.loadTexture(liquid::Uuid::generate()).hasError());
 
   // invalid format
+  auto uuid = liquid::Uuid::generate();
   auto filePath = cache.createTextureFromSource(
-      FixturesPath / "white-image-100x100.png", liquid::Uuid::generate());
+      FixturesPath / "white-image-100x100.png", uuid);
 
-  EXPECT_TRUE(cache.loadTextureFromFile(filePath.getData()).hasError());
+  EXPECT_TRUE(cache.loadTexture(uuid).hasError());
 }
 
 TEST_F(AssetCacheTextureTest, FailsIfTextureIsOneDimensional) {
-  auto filePath = cache.createTextureFromSource(FixturesPath / "1x1-1d.ktx",
-                                                liquid::Uuid::generate());
+  auto uuid = liquid::Uuid::generate();
+  auto filePath =
+      cache.createTextureFromSource(FixturesPath / "1x1-1d.ktx", uuid);
 
-  EXPECT_TRUE(cache.loadTextureFromFile(filePath.getData()).hasError());
+  EXPECT_TRUE(cache.loadTexture(uuid).hasError());
 }
 
 TEST_F(AssetCacheTextureTest, LoadsTexture2D) {
-  auto filePath = cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx",
-                                                liquid::Uuid::generate());
+  auto uuid = liquid::Uuid::generate();
+  auto filePath =
+      cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", uuid);
 
-  auto texture = cache.loadTextureFromFile(filePath.getData());
+  auto texture = cache.loadTexture(uuid);
   EXPECT_TRUE(texture.hasData());
 
   auto &asset = cache.getRegistry().getTextures().getAsset(texture.getData());
@@ -100,9 +103,11 @@ TEST_F(AssetCacheTextureTest, LoadsTexture2D) {
 }
 
 TEST_F(AssetCacheTextureTest, LoadsTextureCubemap) {
-  auto filePath = cache.createTextureFromSource(
-      FixturesPath / "1x1-cubemap.ktx", liquid::Uuid::generate());
-  auto texture = cache.loadTextureFromFile(filePath.getData());
+  auto uuid = liquid::Uuid::generate();
+
+  auto filePath =
+      cache.createTextureFromSource(FixturesPath / "1x1-cubemap.ktx", uuid);
+  auto texture = cache.loadTexture(uuid);
 
   EXPECT_TRUE(texture.hasData());
 

--- a/engine/tests/liquid-tests/scripting/ScriptingSystem.test.cpp
+++ b/engine/tests/liquid-tests/scripting/ScriptingSystem.test.cpp
@@ -12,6 +12,13 @@ public:
     scriptingSystem.observeChanges(entityDatabase);
   }
 
+  liquid::LuaScriptAssetHandle
+  loadLuaScript(liquid::String filename = "scripting-system-tester.lua") {
+    auto uuid = liquid::Uuid::generate();
+    assetCache.createLuaScriptFromSource(FixturesPath / filename, uuid);
+    return assetCache.loadLuaScript(uuid).getData();
+  }
+
   liquid::EntityDatabase entityDatabase;
   liquid::EventSystem eventSystem;
   liquid::AssetCache assetCache;
@@ -23,10 +30,7 @@ using ScriptingSystemDeathTest = ScriptingSystemTest;
 static constexpr float TimeDelta = 0.2f;
 
 TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnUpdate) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
 
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
@@ -43,10 +47,7 @@ TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnUpdate) {
 }
 
 TEST_F(ScriptingSystemTest, DeletesScriptDataWhenComponentIsDeleted) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
 
   static constexpr size_t NumEntities = 20;
 
@@ -87,10 +88,8 @@ TEST_F(ScriptingSystemTest, DeletesScriptDataWhenComponentIsDeleted) {
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnEveryUpdate) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
+
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
 
@@ -108,10 +107,8 @@ TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnEveryUpdate) {
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptStartFunctionOnStart) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
+
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
 
@@ -126,10 +123,8 @@ TEST_F(ScriptingSystemTest, CallsScriptStartFunctionOnStart) {
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptingStartFunctionOnlyOnceOnStart) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
+
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
 
@@ -146,10 +141,7 @@ TEST_F(ScriptingSystemTest, CallsScriptingStartFunctionOnlyOnceOnStart) {
 }
 
 TEST_F(ScriptingSystemTest, RemovesScriptComponentIfInputVarsAreNotSet) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-vars.lua")
-          .getData();
+  auto handle = loadLuaScript("scripting-system-vars.lua");
 
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
@@ -161,10 +153,7 @@ TEST_F(ScriptingSystemTest, RemovesScriptComponentIfInputVarsAreNotSet) {
 }
 
 TEST_F(ScriptingSystemTest, RemovesScriptComponentIfInputVarTypesAreInvalid) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-vars.lua")
-          .getData();
+  auto handle = loadLuaScript("scripting-system-vars.lua");
 
   auto entity = entityDatabase.create();
   liquid::Script script{handle};
@@ -183,10 +172,7 @@ TEST_F(ScriptingSystemTest, RemovesScriptComponentIfInputVarTypesAreInvalid) {
 }
 
 TEST_F(ScriptingSystemTest, SetsVariablesToInputVarsOnStart) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-vars.lua")
-          .getData();
+  auto handle = loadLuaScript("scripting-system-vars.lua");
 
   auto entity = entityDatabase.create();
   liquid::Script script{handle};
@@ -210,10 +196,7 @@ TEST_F(ScriptingSystemTest, SetsVariablesToInputVarsOnStart) {
 }
 
 TEST_F(ScriptingSystemTest, RemovesVariableSetterAfterInputVariablesAreSet) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-vars.lua")
-          .getData();
+  auto handle = loadLuaScript("scripting-system-vars.lua");
 
   auto entity = entityDatabase.create();
   liquid::Script script{handle};
@@ -245,10 +228,8 @@ TEST_F(ScriptingSystemTest, RemovesVariableSetterAfterInputVariablesAreSet) {
 }
 
 TEST_F(ScriptingSystemTest, RegistersEventsOnStart) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
+
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
 
@@ -264,10 +245,8 @@ TEST_F(ScriptingSystemTest, RegistersEventsOnStart) {
 
 TEST_F(ScriptingSystemTest,
        DoesNotCallScriptCollisionEventIfEntityDidNotCollide) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
+
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
 
@@ -283,10 +262,8 @@ TEST_F(ScriptingSystemTest,
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptCollisionStartEventIfEntityCollided) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
+
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
 
@@ -304,10 +281,8 @@ TEST_F(ScriptingSystemTest, CallsScriptCollisionStartEventIfEntityCollided) {
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptCollisionEndEventIfEntityCollided) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
+
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
 
@@ -324,10 +299,8 @@ TEST_F(ScriptingSystemTest, CallsScriptCollisionEndEventIfEntityCollided) {
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptKeyPressEventIfKeyIsPressed) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
+
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
 
@@ -345,10 +318,8 @@ TEST_F(ScriptingSystemTest, CallsScriptKeyPressEventIfKeyIsPressed) {
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptKeyReleaseEventIfKeyIsReleased) {
-  auto handle =
-      assetCache
-          .loadLuaScriptFromFile(FixturesPath / "scripting-system-tester.lua")
-          .getData();
+  auto handle = loadLuaScript();
+
   auto entity = entityDatabase.create();
   entityDatabase.set<liquid::Script>(entity, {handle});
 

--- a/engine/tests/liquid-tests/test-utils/ScriptingInterfaceTestBase.cpp
+++ b/engine/tests/liquid-tests/test-utils/ScriptingInterfaceTestBase.cpp
@@ -15,8 +15,9 @@ LuaScriptingInterfaceTestBase::LuaScriptingInterfaceTestBase(
 liquid::LuaScope &
 LuaScriptingInterfaceTestBase::call(liquid::Entity entity,
                                     const liquid::String &functionName) {
-  auto handle =
-      assetCache.loadLuaScriptFromFile(FixturesPath / mScriptName).getData();
+  auto uuid = liquid::Uuid::generate();
+  assetCache.createLuaScriptFromSource(FixturesPath / mScriptName, uuid);
+  auto handle = assetCache.loadLuaScript(uuid).getData();
 
   entityDatabase.set<liquid::Script>(entity, {handle});
 


### PR DESCRIPTION
- Remove unnecessary methods
- Disallow passing empty uuids to asset cache methods
- Create uuids in editor if a uuid does not already exist